### PR TITLE
Add deceased players endpoint

### DIFF
--- a/lib/db/players.js
+++ b/lib/db/players.js
@@ -50,6 +50,7 @@ async function deceasedPlayers() {
 	return await all(
 		`SELECT 
 		player_name,
+		player_id,
 		deceased,
 		anticapitalism,
 		base_thirst,

--- a/lib/db/players.js
+++ b/lib/db/players.js
@@ -46,6 +46,51 @@ async function playerAttrs(playerId) {
 	);
 }
 
+async function deceasedPlayers() {
+	return await all(
+		`SELECT 
+		player_name,
+		deceased,
+		anticapitalism,
+		base_thirst,
+		buoyancy,
+		chasiness,
+		coldness,
+		continuation,
+		divinity,
+		ground_friction,
+		indulgence,
+		laserlikeness,
+		martyrdom,
+		moxie,
+		musclitude,
+		omniscience,
+		overpowerment,
+		patheticism,
+		ruthlessness,
+		shakespearianism,
+		suppression,
+		tenaciousness,
+		thwackability,
+		tragicness,
+		unthwackability,
+		watchfulness,
+		pressurization,
+		cinnamon,
+		total_fingers,
+		soul,
+		fate,
+		peanut_allergy,
+		armor,
+		bat,
+		ritual,
+		coffee,
+		blood
+		FROM players WHERE deceased AND valid_until IS NULL`
+	);
+}
+
 module.exports = {
 	playerAttrs,
+	deceasedPlayers
 }

--- a/lib/routes/v1.js
+++ b/lib/routes/v1.js
@@ -3,7 +3,7 @@ const Router = require('express-promise-router');
 const { allWithCount, all } = require('../db/db.js');
 const { atBats, plateAppearances, hits, timesOnBase, battingAverage, onBasePercentage, slugging, onBasePlusSlugging, outsRecorded, hitsRecorded, walksRecorded, whip, earnedRuns, era, countBattersByType, countPitchersByType } = require('../db/stats.js');
 const { resultsWithCount, normalizeCommaSeparatedParam } = require('../utils/utils.js');
-const { playerAttrs } = require('../db/players.js');
+const { playerAttrs, deceasedPlayers } = require('../db/players.js');
 const { currentRoster } = require('../db/rosters.js');
 
 const router = new Router();
@@ -487,6 +487,18 @@ router.get('/playerAttrs', async (req, res) => {
 
 	res.json(await playerAttrs(playerId));
 });
+
+/**
+ * Get all currently decieased players
+ * 
+ * @route GET /deceased
+ * @group Players
+ * @summary Get a list of all currently deceased players
+ * @returns {object} 200 - Array of player objects
+ */
+router.get('/deceased', async (req,res)=>{
+  res.json(await deceasedPlayers())
+})
 
 /**
  * Get the current roster for a given team


### PR DESCRIPTION
Endpoint `GET /deceased` now returns a list of player objects where all players are deceased, this code does work but is now pending on the deceased values actually being in the database