### PR TITLE
Implemented get team by slug

### DIFF
--- a/lib/db/teams.js
+++ b/lib/db/teams.js
@@ -13,7 +13,17 @@ async function currentTeamStars() {
 	);
 }
 
+async function teamIdBySlug(slug) {
+	return await all(
+		`SELECT team_id
+		 FROM data.teams_current
+		 WHERE url_slug = $1`,
+		 [slug]
+	)
+}
+
 module.exports = {
 	currentTeams,
-	currentTeamStars
+	currentTeamStars,
+	teamIdBySlug
 }

--- a/lib/routes/v1.js
+++ b/lib/routes/v1.js
@@ -6,7 +6,7 @@ const { resultsWithCount, normalizeCommaSeparatedParam } = require('../utils/uti
 const { deceasedPlayers, playerIdsByName, playerIdBySlug, playerInfoCurrent, playerInfoAll, taggedPlayers, allPlayers, allPlayersForGameday } = require('../db/players.js');
 const { currentRoster } = require('../db/rosters.js');
 const { seasonBattingStats, lifetimeBattingStats, seasonPitchingStats, lifetimePitchingStats, lifetimeFieldingStats, seasonFieldingStats, lifetimeRunningStats, seasonRunningStats, seasonLeaders} = require('../db/statviews.js');
-const { currentTeams, currentTeamStars } = require('../db/teams.js');
+const { currentTeams, currentTeamStars, teamIdBySlug } = require('../db/teams.js');
 
 const router = new Router();
 
@@ -432,23 +432,30 @@ router.get('/taggedPlayers', async (req, res)=>{
 })
 
 /**
- * Get the current roster for a given team
+ * Get the current roster for a given team, using either ID or slug.
  * 
  * @route GET /currentRoster
  * @group Teams
  * @summary Get the current roster for a given team
- * @param {string} teamId.query - The ID of the team
+ * @param {string} teamId.query - The ID of the team (takes precedence if slug is given)
+ * @param {string} slug.query - The slug of the team
  * @returns {[RosterEntry]} 200 - array of roster information
  */
 router.get('/currentRoster', async (req, res) => {
-	const teamId = req.query.teamId;
+	let teamId = req.query.teamId;
+	let slug = req.query.slug;
 
-	if(!teamId) {
+	if(!teamId && !slug) {
 		res.json({
 			error: true,
-			message: 'Must specify a teamId.',
+			message: 'Must specify a teamId or slug.',
 		});
 		return;
+	}
+
+	if(!teamId) {
+		let rawId = await(teamIdBySlug(slug));
+		teamId = rawId[0].team_id
 	}
 
 	res.json(await currentRoster(teamId));


### PR DESCRIPTION
/currentRoster can now get a team's roster by slug. If both an id and slug are given, the id is used to get the roster. 