### PR TITLE
Fix error message

### DIFF
--- a/lib/routes/v1.js
+++ b/lib/routes/v1.js
@@ -477,7 +477,7 @@ router.get('/playerInfo', async (req, res) => {
     } else {
       res.json({
         error: true,
-        message: 'Player ID was invalid. Please try again.',
+        message: 'No players were found with that name. Please try again.',
       });
 
       return;


### PR DESCRIPTION
Fix the error message on /playerInfo to be more helpful when the name search returns no matching IDs.