### PR TITLE
Add configurable API host for Swagger

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /usr/src/app
 
 # Installing dependencies
 COPY package*.json ./
-RUN npm install
+RUN yarn install
 
 # Copying source files
 COPY . .

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,10 @@ expressSwagger({
       title: 'Datablase',
       version: '1.0.0',
     },
-    host: 'api.blaseball-reference.com',
+    host:
+      'SIBR_API_HOST' in process.env
+        ? process.env.SIBR_API_HOST
+        : 'api.blaseball-reference.com',
     basePath: '/v1',
     produces: ['application/json'],
     schemes: ['https'],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sibr-api",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "API for SIBR statistics.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
This change will allow us to set a specific API host for Swagger via the `SIBR_API_HOST` environment variable. If the variable isn't set then it will fall back to `api.blaseball-reference.com`. This should be useful for the upcoming server migration as well as the new staging environment.