### PR TITLE
Add more v2 routes and update Prisma schema

### DIFF
--- a/lib/controllers/players.js
+++ b/lib/controllers/players.js
@@ -6,7 +6,7 @@ import {
 
 const prisma = new PrismaClient();
 
-async function players({ season }) {
+export async function players({ season }) {
   if (isNaN(season)) {
     season = await getCurrentSeason();
   }
@@ -50,7 +50,7 @@ async function players({ season }) {
   });
 }
 
-async function deceasedPlayers() {
+export async function deceasedPlayers() {
   return await prisma.player.findMany({
     where: {
       deceased: true,
@@ -74,7 +74,7 @@ async function playerIdBySlug(slug) {
   });
 }
 
-async function playerInfoCurrent(playerIds) {
+export async function playerInfoCurrent(playerIds) {
   return await prisma.player.findMany({
     where: {
       player_id: {
@@ -84,10 +84,3 @@ async function playerInfoCurrent(playerIds) {
     },
   });
 }
-
-module.exports = {
-  deceasedPlayers,
-  players,
-  playerInfoCurrent,
-  playerIdBySlug,
-};

--- a/lib/controllers/stats.js
+++ b/lib/controllers/stats.js
@@ -1,0 +1,79 @@
+const { PrismaClient } = require('@prisma/client');
+import { getCurrentSeason } from '../controllers/timeMap.js';
+
+const prisma = new PrismaClient();
+
+// @TODO: The 'teamId' is currently unsupported for pitching stats
+export async function playerStats({
+  group,
+  limit,
+  order,
+  season,
+  sortStat,
+  teamId,
+  type = 'season',
+}) {
+  if (type === 'season' && isNaN(season)) {
+    season = await getCurrentSeason();
+  }
+
+  const statGroups = group.split(',');
+
+  let response = [];
+
+  // @TODO: Add career stats
+  for (const statGroup of statGroups) {
+    let statGroupResult = {};
+    let view;
+
+    if (statGroup === 'hitting') {
+      view = prisma.playerBattingStatsSeason;
+    } else if (statGroup === 'pitching') {
+      view = prisma.playerPitchingStatsSeason;
+    } else {
+      throw new Error(
+        `Unsupported value provided for 'group' parameter: ${statGroup}`
+      );
+    }
+
+    const viewResults = await view.findMany({
+      where: {
+        season,
+        // @TODO: Remove conditional once pitching view includes a 'team_id' column
+        team_id: statGroup === 'hitting' ? teamId : undefined,
+      },
+      take: limit,
+      orderBy: {
+        [sortStat]: order,
+      },
+    });
+
+    statGroupResult.group = statGroup;
+    statGroupResult.type = type;
+    statGroupResult.totalSplits = viewResults.length;
+    statGroupResult.splits = [];
+
+    for (const record of viewResults) {
+      const { player_id, player_name, team, team_id, season, ...stat } = record;
+
+      statGroupResult.splits.push({
+        season,
+        stat: {
+          ...stat,
+        },
+        player: {
+          id: player_id,
+          fullName: player_name,
+        },
+        team: {
+          id: team_id,
+          name: team,
+        },
+      });
+    }
+
+    response.push(statGroupResult);
+  }
+
+  return response;
+}

--- a/lib/controllers/teams.js
+++ b/lib/controllers/teams.js
@@ -6,7 +6,7 @@ import {
 
 const prisma = new PrismaClient();
 
-async function team({ season, teamId }) {
+export async function team({ season, teamId }) {
   if (isNaN(season)) {
     season = await getCurrentSeason();
   }
@@ -41,7 +41,7 @@ async function team({ season, teamId }) {
   });
 }
 
-async function teams({ season }) {
+export async function teams({ season }) {
   if (isNaN(season)) {
     season = await getCurrentSeason();
   }
@@ -78,8 +78,3 @@ async function teams({ season }) {
     distinct: ['team_id'],
   });
 }
-
-module.exports = {
-  team,
-  teams,
-};

--- a/lib/controllers/teams.js
+++ b/lib/controllers/teams.js
@@ -6,6 +6,41 @@ import {
 
 const prisma = new PrismaClient();
 
+async function team({ season, teamId }) {
+  if (isNaN(season)) {
+    season = await getCurrentSeason();
+  }
+
+  const [
+    seasonStartTimestamp,
+    seasonEndTimestamp,
+  ] = await getSeasonStartAndEndTimestamps(season);
+
+  return await prisma.team.findFirst({
+    where: {
+      team_id: teamId,
+      valid_from: {
+        lte: seasonStartTimestamp,
+      },
+      OR: [
+        {
+          valid_until: {
+            gte: seasonEndTimestamp,
+          },
+        },
+        {
+          valid_until: null,
+        },
+      ],
+    },
+    orderBy: [
+      {
+        valid_from: 'desc',
+      },
+    ],
+  });
+}
+
 async function teams({ season }) {
   if (isNaN(season)) {
     season = await getCurrentSeason();
@@ -45,5 +80,6 @@ async function teams({ season }) {
 }
 
 module.exports = {
+  team,
   teams,
 };

--- a/lib/controllers/timeMap.js
+++ b/lib/controllers/timeMap.js
@@ -7,9 +7,6 @@ export async function getCurrentSeason() {
     max: {
       season: true,
     },
-    where: {
-      time_event_type: 'GAMEDAY',
-    },
   });
 
   return currentSeason.max.season;
@@ -39,7 +36,6 @@ export async function getFirstDayAndLastDayForSeason(season) {
     },
     where: {
       season,
-      time_event_type: 'GAMEDAY',
     },
   });
 

--- a/lib/routes/v2.js
+++ b/lib/routes/v2.js
@@ -1,5 +1,6 @@
 const Router = require('express-promise-router');
 
+const { playerStats } = require('../controllers/stats.js');
 const { players } = require('../controllers/players.js');
 const { team, teams } = require('../controllers/teams.js');
 
@@ -31,7 +32,7 @@ router.get('/teams', async (req, res) => {
  * @summary Get a specific team's details
  * @returns {[object]} 200 - a team's details
  */
-router.get('/teams/:teamId', async (req, res) => {
+router.get('/teams/:teamId', async (req, res, next) => {
   const season = Number(req.query.season);
   const teamId = req.params.teamId;
 
@@ -59,6 +60,51 @@ router.get('/players', async (req, res) => {
   const season = Number(req.query.season);
 
   const result = await players({ season });
+
+  res.json(result);
+});
+
+/**
+ * Get stats for players.
+ *
+ * @route GET /stats
+ * @group Stats
+ * @group APIv2
+ * @summary Get a list of player stats
+ * @returns {[object]} 200 - list of player stats
+ */
+router.get('/stats', async (req, res, next) => {
+  const { group, order, sortStat, teamId, type } = req.query;
+  const limit =
+    req.query.limit !== undefined ? Number(req.query.limit) : undefined;
+  const season =
+    req.query.season !== undefined ? Number(req.query.season) : undefined;
+
+  if (group === undefined) {
+    const err = new Error(
+      'Required query param `group` missing. Available groups: hitting, pitching.'
+    );
+    err.status = 400;
+    next(err);
+  }
+
+  if (type === undefined) {
+    const err = new Error(
+      'Required query param `type` missing. Available types: season.'
+    );
+    err.status = 400;
+    next(err);
+  }
+
+  const result = await playerStats({
+    group,
+    limit,
+    order,
+    season,
+    sortStat,
+    teamId,
+    type,
+  });
 
   res.json(result);
 });

--- a/lib/routes/v2.js
+++ b/lib/routes/v2.js
@@ -1,7 +1,7 @@
 const Router = require('express-promise-router');
 
 const { players } = require('../controllers/players.js');
-const { teams } = require('../controllers/teams.js');
+const { team, teams } = require('../controllers/teams.js');
 
 const router = new Router();
 
@@ -18,6 +18,30 @@ router.get('/teams', async (req, res) => {
   const season = Number(req.query.season);
 
   const result = await teams({ season });
+
+  res.json(result);
+});
+
+/**
+ * Get a single team's details for a given season. Defaults to current season.
+ *
+ * @route GET /teams/:teamId
+ * @group Teams
+ * @group APIv2
+ * @summary Get a specific team's details
+ * @returns {[object]} 200 - a team's details
+ */
+router.get('/teams/:teamId', async (req, res) => {
+  const season = Number(req.query.season);
+  const teamId = req.params.teamId;
+
+  if (teamId === undefined) {
+    const err = new Error('Required query param `teamId` missing');
+    err.status = 400;
+    next(err);
+  }
+
+  const result = await team({ season, teamId });
 
   res.json(result);
 });

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "author": "Corvimae",
   "license": "MIT",
   "dependencies": {
-    "@prisma/client": "^2.10.0",
+    "@prisma/client": "^2.12.1",
     "core-js": "^3.6.5",
     "cors": "^2.8.5",
     "dotenv": "^8.2.0",
@@ -27,7 +27,7 @@
     "@babel/core": "^7.12.3",
     "@babel/node": "^7.12.1",
     "@babel/preset-env": "^7.12.1",
-    "@prisma/cli": "^2.9.0",
+    "@prisma/cli": "^2.12.1",
     "husky": ">=4",
     "lint-staged": ">=10",
     "nodemon": "^2.0.5",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -315,3 +315,70 @@ model CurrentTeamRoster {
 
   @@map("rosters_current")
 }
+
+// @View - Must be manually updated with every new Prisma introspection
+model PlayerBattingStatsSeason {
+  player_id             String
+  player_name           String
+  team_id               String
+  team                  String
+  season                Int
+  batting_average       Float?
+  on_base_percentage    Float?
+  slugging              Float?
+  plate_appearances     Int
+  at_bats               Int
+  walks                 Int
+  singles               Int
+  doubles               Int
+  triples               Int
+  quadruples            Int
+  home_runs             Int
+  runs_batted_in        Int
+  strikeouts            Int
+  sacrifices            Int
+  at_bats_risp          Int
+  hits_risps            Int
+  batting_average_risp  Float?
+  on_base_slugging      Float?
+  total_bases           Int
+  hbps                  Int
+  ground_outs           Int
+  flyouts               Int
+  gidps                 Int
+
+  @@id(fields: [player_id, season])
+  @@map("batting_stats_player_season")
+}
+
+
+// @View - Must be manually updated with every new Prisma introspection
+model PlayerPitchingStatsSeason {
+  player_id       String
+  player_name     String
+  season          Int
+  team_ids        String[]
+  games           Int
+  wins            Int
+  losses          Int
+  pitch_count     Int
+  batters_faced   Int
+  outs_recorded   Int
+  innings         Int
+  runs_allowed    Int
+  shutouts        Int
+  quality_starts  Int
+  strikeouts      Int
+  walks           Int
+  hrs_allowed     Int
+  hits_allowed    Int
+  hbps            Float
+  era             Float
+  bb_per_9        Float
+  hits_per_9      Float
+  k_per_9         Float
+  hr_per_9        Float
+
+  @@id(fields: [player_id, season])
+  @@map("pitching_stats_player_season")
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,10 +15,10 @@ model AppliedPatches {
 }
 
 model ChroniclerHashGameEvent {
-  chronicler_hash_game_event_id Int          @id @default(autoincrement())
+  chronicler_hash_game_event_id Int        @id @default(autoincrement())
   update_hash                   String?
   game_event_id                 Int?
-  game_events                   GameEvent?   @relation(fields: [game_event_id], references: [id])
+  game_events                   GameEvent? @relation(fields: [game_event_id], references: [id])
 
   @@index([game_event_id], name: "chronicler_hash_game_event_indx_game_event_id")
   @@map("chronicler_hash_game_event")
@@ -36,7 +36,7 @@ model ChroniclerMeta {
 }
 
 model GameEventBaseRunner {
-  id                     Int          @id @default(autoincrement())
+  id                     Int        @id @default(autoincrement())
   game_event_id          Int?
   runner_id              String?
   responsible_pitcher_id String?
@@ -45,15 +45,15 @@ model GameEventBaseRunner {
   was_base_stolen        Boolean?
   was_caught_stealing    Boolean?
   was_picked_off         Boolean?
-  runner_scored          Boolean?     @default(false)
+  runner_scored          Boolean?   @default(false)
   runs_scored            Float?
-  game_events            GameEvent?   @relation(fields: [game_event_id], references: [id])
+  game_events            GameEvent? @relation(fields: [game_event_id], references: [id])
 
   @@map("game_event_base_runners")
 }
 
 model GameEvent {
-  id                                 Int                          @id @default(autoincrement())
+  id                                 Int                       @id @default(autoincrement())
   perceived_at                       DateTime?
   game_id                            String?
   event_type                         String?
@@ -67,8 +67,8 @@ model GameEvent {
   pitcher_team_id                    String?
   home_score                         Float?
   away_score                         Float?
-  home_strike_count                  Int?                         @default(dbgenerated())
-  away_strike_count                  Int?                         @default(dbgenerated())
+  home_strike_count                  Int?                      @default(3)
+  away_strike_count                  Int?                      @default(3)
   batter_count                       Int?
   pitches                            String[]
   total_strikes                      Int?
@@ -79,7 +79,7 @@ model GameEvent {
   lineup_position                    Int?
   is_last_event_for_plate_appearance Boolean?
   bases_hit                          Int?
-  runs_batted_in                     Int?
+  runs_batted_in                     Float?
   is_sacrifice_hit                   Boolean?
   is_sacrifice_fly                   Boolean?
   outs_on_play                       Int?
@@ -99,24 +99,27 @@ model GameEvent {
   parsing_error_list                 String[]
   fixed_error                        Boolean?
   fixed_error_list                   String[]
-  home_ball_count                    Int?                         @default(4)
-  away_ball_count                    Int?                         @default(4)
-  away_base_count                    Int?                         @default(4)
-  home_base_count                    Int?                         @default(4)
-  games                              Game?                        @relation(fields: [game_id], references: [game_id])
+  home_ball_count                    Int?                      @default(4)
+  away_ball_count                    Int?                      @default(4)
+  away_base_count                    Int?                      @default(4)
+  home_base_count                    Int?                      @default(4)
+  tournament                         Int?
+  games                              Game?                     @relation(fields: [game_id], references: [game_id])
   chronicler_hash_game_event         ChroniclerHashGameEvent[]
   game_event_base_runners            GameEventBaseRunner[]
   outcomes                           Outcome[]
 
   @@unique([game_id, event_index], name: "no_dupes")
   @@index([event_type], name: "game_events_indx_event_type")
+  @@index([game_id], name: "game_events_indx_game_id")
   @@map("game_events")
 }
 
 model Game {
-  game_id                String        @id
+  game_id                String      @id
   day                    Int
   season                 Int
+  tournament             Int
   last_game_event        Int?
   home_odds              Float?
   away_odds              Float?
@@ -150,12 +153,12 @@ model ImportedLog {
 }
 
 model Outcome {
-  id            Int          @id @default(autoincrement())
+  id            Int        @id @default(autoincrement())
   game_event_id Int?
   entity_id     String?
   event_type    String?
   original_text String?
-  game_events   GameEvent?   @relation(fields: [game_event_id], references: [id])
+  game_events   GameEvent? @relation(fields: [game_event_id], references: [id])
 
   @@map("outcomes")
 }
@@ -167,6 +170,7 @@ model PlayerModification {
   valid_from              DateTime?
   valid_until             DateTime?
 
+  @@index([player_id, valid_from, valid_until], name: "player_modifications_indx_player_id_timespan")
   @@map("player_modifications")
 }
 
@@ -190,104 +194,121 @@ model TeamRoster {
   position_type_id Float?
 
   @@index([valid_until, team_id, position_id, position_type_id], name: "team_roster_idx")
+  @@index([player_id, valid_from, valid_until], name: "team_roster_indx_player_id_timespan")
   @@map("team_roster")
 }
 
 model TimeMap {
-  season          Int
-  day             Int
-  first_time      DateTime
-  time_map_id     Int       @id @default(autoincrement())
-  time_event_type String?
+  season      Int
+  day         Int
+  first_time  DateTime?
+  time_map_id Int       @id @default(autoincrement())
+  phase_id    Int?
 
-  @@unique([season, day, time_event_type], name: "season_day_type_unique")
+  @@unique([season, day, phase_id], name: "season_day_unique")
   @@map("time_map")
 }
 
-// Views
-
+// @View - Must be manually updated with every new Prisma introspection
 model Player {
-  player_id           String
-  url_slug            String?
-  team_id             String?
-  team                String?
-  current_state       String?
+  player_id        String
+  player_name      String?
+  valid_from       DateTime
+  valid_until      DateTime?
+  deceased         Boolean?
+  anticapitalism   Float?
+  base_thirst      Float?
+  buoyancy         Float?
+  chasiness        Float?
+  coldness         Float?
+  continuation     Float?
+  divinity         Float?
+  ground_friction  Float?
+  indulgence       Float?
+  laserlikeness    Float?
+  martyrdom        Float?
+  moxie            Float?
+  musclitude       Float?
+  omniscience      Float?
+  overpowerment    Float?
+  patheticism      Float?
+  ruthlessness     Float?
+  shakespearianism Float?
+  suppression      Float?
+  tenaciousness    Float?
+  thwackability    Float?
+  tragicness       Float?
+  unthwackability  Float?
+  watchfulness     Float?
+  pressurization   Float?
+  cinnamon         Float?
+  total_fingers    Int?
+  soul             Int?
+  fate             Int?
+  peanut_allergy   Boolean?
+  armor            String?
+  bat              String?
+  ritual           String?
+  coffee           String?
+  blood            String?
+  url_slug         String?
+
   current_location    String?
-  position_type       String?
-  position_id         Int?
-  valid_from          DateTime
-  valid_until         DateTime?
+  current_state       String?
   gameday_from        Int
+  gamestate_from      String
+  position_id         Int?
+  position_type       String?
   season_from         Int
-  deceased            Boolean?
-  player_name         String?
-  anticapitalism      Float?
-  base_thirst         Float?
-  buoyancy            Float?
-  chasiness           Float?
-  coldness            Float?
-  continuation        Float?
-  divinity            Float?
-  ground_friction     Float?
-  indulgence          Float?
-  laserlikeness       Float?
-  martyrdom           Float?
-  moxie               Float?
-  musclitude          Float?
-  omniscience         Float?
-  overpowerment       Float?
-  patheticism         Float?
-  ruthlessness        Float?
-  shakespearianism    Float?
-  suppression         Float?
-  tenaciousness       Float?
-  thwackability       Float?
-  tragicness          Float?
-  unthwackability     Float?
-  watchfulness        Float?
-  pressurization      Float?
-  cinnamon            Float?
-  total_fingers       Int?
-  soul                Int?
-  fate                Int?
-  peanut_allergy      Boolean?
-  armor               String?
-  bat                 String?
-  ritual              String?
-  coffee              String?
-  blood               String?
+  team                String?
+  team_abbreviation   String?
+  team_id             String?
+  modifications       String[]
+  baserunning_rating  Int?
+  baserunning_stars   Int?
+  batting_rating      Int?
+  batting_stars       Int?
+  defense_rating      Int?
+  defense_stars       Int?
+  pitching_rating     Int?
+  pitching_stars      Int?
 
   @@id(fields: [player_id, valid_from])
   @@map("players_info_expanded_all")
 }
 
+// @View - Must be manually updated with every new Prisma introspection
 model Team {
-  team_id         String
-  location        String
-  nickname        String
-  full_name       String
-  url_slug        String
-  valid_from      DateTime
-  valid_until     DateTime?
-  gameday_from    Int
-  season_from     Int
-  division        String?
-  division_id     String?
-  league          String?
-  league_id       String?
+  team_id             String
+  location            String
+  nickname            String
+  full_name           String
+  team_abbreviation   String?
+  url_slug            String
+  current_team_status String
+  valid_from          DateTime
+  valid_until         DateTime?
+  gameday_from        Int
+  season_from         Int
+  division            String?
+  division_id         String?
+  league              String?
+  league_id           String?
+  tournament_name     String?
+  modifications       String[]
 
   @@id(fields: [team_id, valid_from])
   @@map("teams_info_expanded_all")
 }
 
-// Current Team Roster View
+// @View - Must be manually updated with every new Prisma introspection
 model CurrentTeamRoster {
-  player_id       String     @id
-  team_id         String
   valid_from      DateTime
   gameday_from    Int
   season_from     Int
+  team_id         String
   nickname        String
+  player_id       String    @id
   player_name     String
   position_type   String
   position_id     Int

--- a/yarn.lock
+++ b/yarn.lock
@@ -873,22 +873,35 @@
   dependencies:
     chokidar "2.1.8"
 
-"@prisma/cli@^2.9.0":
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/@prisma/cli/-/cli-2.9.0.tgz#c6f6652890783b899f266537e90e69c3481f5474"
-  integrity sha512-wPk4ehyTtVM7ZarWs16MhOc6kwLV/gZFardMvUeh46rlBwrklMdKtNChzzPa3wurrUPQ5KTbuRBz5Mgf7AdD/w==
+"@prisma/bar@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@prisma/bar/-/bar-0.0.1.tgz#088c4fbbb79c588391437ade9fd3a85527e753b3"
+  integrity sha512-FVLhwVkbfhXlBhroWfIXMLi+3Jh9IEzYp+9z+MUUiw3ZsbcoAil7CN9/QIjHc4/TcCRyRfuSmT7qCnn4O+TjJw==
 
-"@prisma/client@^2.10.0":
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.10.0.tgz#967223bb1e1b21ddea9a098dc9758f7ace03d828"
-  integrity sha512-TZoT5SYmCkVqMt8rKp3NAUm6UTqjNUMp2W94IcVn2d5DVkOR5TZGkxP/u8KuSoY3KQWIG+KQy/azIKetKxc+LQ==
+"@prisma/cli@^2.12.1":
+  version "2.12.1"
+  resolved "https://registry.yarnpkg.com/@prisma/cli/-/cli-2.12.1.tgz#1f52ab2a363ae4cc88d4d18933bd304ed7f80612"
+  integrity sha512-obkwK95dEeifCdVehG0rS0BlPQGLsOtc9U1MgbrjNX3MnhXQdwROnvymfPB3DBlNyoLoHGklPgi9UlwBokNXcQ==
   dependencies:
-    "@prisma/engines-version" "2.10.0-16-af1ae11a423edfb5d24092a85be11fa77c5e499c"
+    "@prisma/bar" "^0.0.1"
+    "@prisma/engines" "2.12.0-18.cf0680a1bfe8d5e743dc659cc7f08009f9587d58"
 
-"@prisma/engines-version@2.10.0-16-af1ae11a423edfb5d24092a85be11fa77c5e499c":
-  version "2.10.0-16-af1ae11a423edfb5d24092a85be11fa77c5e499c"
-  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-2.10.0-16-af1ae11a423edfb5d24092a85be11fa77c5e499c.tgz#4d02db85e5a7250676a648d3eab0d579455c1eea"
-  integrity sha512-8dW/oSDBv3fovNzTn2sjpITgD4IhHYPnmkbPp4Gv4rqjB14tpB0OuU1xkygVRIRJisTBRoYyjfiVaaWea/e57A==
+"@prisma/client@^2.12.1":
+  version "2.12.1"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.12.1.tgz#ff655c9cc1188035303f374d2f9f794b66fc18c7"
+  integrity sha512-HP4/E9sRdxw/FB7XP4EeRa5ri8Lp1U/L7G4VAA95aM8C+8ARioQHMNDpEjC83NrOrOr4EcaZV5pXDDQL1H+F0g==
+  dependencies:
+    "@prisma/engines-version" "2.12.0-18.cf0680a1bfe8d5e743dc659cc7f08009f9587d58"
+
+"@prisma/engines-version@2.12.0-18.cf0680a1bfe8d5e743dc659cc7f08009f9587d58":
+  version "2.12.0-18.cf0680a1bfe8d5e743dc659cc7f08009f9587d58"
+  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-2.12.0-18.cf0680a1bfe8d5e743dc659cc7f08009f9587d58.tgz#428f8996f88c92a4142e35f196584a5e17c95871"
+  integrity sha512-IHb/Jag1Wmoq5tLZhOHP5zqLHEXqQEfrHb6l0drIBSvh2AF7yWQ3yyuD0ZEb1Nq37SvbBgop5wrWMOU8YWFTGQ==
+
+"@prisma/engines@2.12.0-18.cf0680a1bfe8d5e743dc659cc7f08009f9587d58":
+  version "2.12.0-18.cf0680a1bfe8d5e743dc659cc7f08009f9587d58"
+  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-2.12.0-18.cf0680a1bfe8d5e743dc659cc7f08009f9587d58.tgz#0e23c811cfa2f58650bb3c04394b1ac0d9dac78a"
+  integrity sha512-F6RmUZ5JpPWxmGvVDji8c4gepHIGkvYbtuFi0IoDDJVaCVo8yS656stciKFyswI6/BLWXa0X47/MIMbz6nzw7g==
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"


### PR DESCRIPTION
Adds v2 routes for `/teams/:teamId` and `/stats`. The `/stats` route is incomplete and only serves player season stats for pitching and hitting. Also, the `teamId` filter does not work on pitching splits due to the missing `team_id` and `team_name` columns in the database view.