### PR TITLE
Add player postseason stats to `/v2/stats` and create `/v2/players/:playerIdOrSlug`

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,7 @@
+SIBR_PRODUCTION=0
+PGUSER=dbuser
+PGHOST=database.server.com
+PGPASSWORD=secretpassword
+PGDATABASE=mydb
+PGPORT=3211
+DATABASE_URL=postgresql://dbuser:secretpassword@database.server.com:5432/mydb?schema=data

--- a/README.md
+++ b/README.md
@@ -22,4 +22,5 @@ PGHOST=database.server.com
 PGPASSWORD=secretpassword
 PGDATABASE=mydb
 PGPORT=3211
+DATABASE_URL="postgresql://username:password@localhost:5432/database?schema=data"
 ```

--- a/lib/controllers/players.js
+++ b/lib/controllers/players.js
@@ -7,14 +7,18 @@ import {
 const prisma = new PrismaClient();
 
 export async function players({ season }) {
-  if (isNaN(season)) {
+  if (season === 'current') {
     season = await getCurrentSeason();
   }
 
-  const [
-    seasonStartTimestamp,
-    seasonEndTimestamp,
-  ] = await getSeasonStartAndEndTimestamps(season);
+  let seasonStartTimestamp, seasonEndTimestamp;
+
+  if (season !== undefined) {
+    [
+      seasonStartTimestamp,
+      seasonEndTimestamp,
+    ] = await getSeasonStartAndEndTimestamps(season);
+  }
 
   return await prisma.player.findMany({
     where: {
@@ -46,6 +50,18 @@ export async function players({ season }) {
         valid_from: 'desc',
       },
     ],
+    distinct: ['player_id'],
+  });
+}
+
+export async function player(playerId, { findByField = 'player_id' } = {}) {
+  return await prisma.player.findFirst({
+    where: {
+      [findByField]: playerId,
+    },
+    orderBy: {
+      valid_from: 'desc',
+    },
     distinct: ['player_id'],
   });
 }

--- a/lib/controllers/stats.js
+++ b/lib/controllers/stats.js
@@ -1,46 +1,61 @@
 const { PrismaClient } = require('@prisma/client');
 import { getCurrentSeason } from '../controllers/timeMap.js';
+import { getSeasonStartAndEndTimestamps } from '../controllers/timeMap.js';
 
 const prisma = new PrismaClient();
 
-// @TODO: The 'teamId' is currently unsupported for pitching stats
+// @TODO: Add explicit types for career, single season, single game, etc
 export async function playerStats({
+  gameType = 'R',
   group,
   limit,
   order,
+  playerId,
   season,
   sortStat,
   teamId,
   type = 'season',
 }) {
-  if (type === 'season' && isNaN(season)) {
+  if (type === 'season' && season === 'current') {
     season = await getCurrentSeason();
   }
 
   const statGroups = group.split(',');
 
+  // A map of players' teams and the seasons in which they appear
+  const teamsBySeason = {};
+
   let response = [];
 
-  // @TODO: Add career stats
   for (const statGroup of statGroups) {
     let statGroupResult = {};
     let view;
 
-    if (statGroup === 'hitting') {
-      view = prisma.playerBattingStatsSeason;
-    } else if (statGroup === 'pitching') {
-      view = prisma.playerPitchingStatsSeason;
+    if (type === 'season') {
+      if (statGroup === 'hitting' && gameType === 'R') {
+        view = prisma.playerBattingStatsSeason;
+      } else if (statGroup === 'hitting' && gameType === 'P') {
+        view = prisma.playerBattingStatsPostseason;
+      } else if (statGroup === 'pitching' && gameType === 'R') {
+        view = prisma.playerPitchingStatsSeason;
+      } else if (statGroup === 'pitching' && gameType === 'P') {
+        view = prisma.playerPitchingStatsPostseason;
+      } else {
+        throw new Error(
+          `Unsupported value provided for 'group' parameter: ${statGroup}`
+        );
+      }
     } else {
       throw new Error(
-        `Unsupported value provided for 'group' parameter: ${statGroup}`
+        `Unsupported value provided for 'type' parameter: ${type}`
       );
     }
 
     const viewResults = await view.findMany({
       where: {
         season,
-        // @TODO: Remove conditional once pitching view includes a 'team_id' column
-        team_id: statGroup === 'hitting' ? teamId : undefined,
+        player_id: playerId,
+        team_id: teamId,
       },
       take: limit,
       orderBy: {
@@ -56,23 +71,71 @@ export async function playerStats({
     for (const record of viewResults) {
       const { player_id, player_name, team, team_id, season, ...stat } = record;
 
+      if (!Object.prototype.hasOwnProperty.call(teamsBySeason, season)) {
+        teamsBySeason[season] = {};
+      }
+
+      if (
+        !Object.prototype.hasOwnProperty.call(teamsBySeason[season], team_id)
+      ) {
+        teamsBySeason[season][team_id] = {};
+      }
+
       statGroupResult.splits.push({
         season,
-        stat: {
-          ...stat,
-        },
+        stat,
         player: {
           id: player_id,
           fullName: player_name,
         },
-        team: {
-          id: team_id,
-          name: team,
-        },
+        team: team_id,
       });
     }
 
     response.push(statGroupResult);
+  }
+
+  // Fetch teams from relevant seasons
+  for (const season in teamsBySeason) {
+    for (const team_id in teamsBySeason[season]) {
+      const [
+        seasonStartTimestamp,
+        seasonEndTimestamp,
+      ] = await getSeasonStartAndEndTimestamps(Number(season));
+
+      const result = await prisma.team.findFirst({
+        where: {
+          team_id,
+          valid_from: {
+            lte: seasonStartTimestamp,
+          },
+          OR: [
+            {
+              valid_until: {
+                gte: seasonEndTimestamp,
+              },
+            },
+            {
+              valid_until: null,
+            },
+          ],
+        },
+        orderBy: [
+          {
+            valid_from: 'desc',
+          },
+        ],
+      });
+
+      teamsBySeason[season][team_id] = result;
+    }
+  }
+
+  // Insert teams into splits
+  for (const statGroup of response) {
+    for (const split of statGroup.splits) {
+      split.team = teamsBySeason[split.season][split.team];
+    }
   }
 
   return response;

--- a/lib/controllers/teams.js
+++ b/lib/controllers/teams.js
@@ -7,14 +7,18 @@ import {
 const prisma = new PrismaClient();
 
 export async function team({ season, teamId }) {
-  if (isNaN(season)) {
+  if (season === 'current') {
     season = await getCurrentSeason();
   }
 
-  const [
-    seasonStartTimestamp,
-    seasonEndTimestamp,
-  ] = await getSeasonStartAndEndTimestamps(season);
+  let seasonStartTimestamp, seasonEndTimestamp;
+
+  if (season !== undefined) {
+    [
+      seasonStartTimestamp,
+      seasonEndTimestamp,
+    ] = await getSeasonStartAndEndTimestamps(season);
+  }
 
   return await prisma.team.findFirst({
     where: {
@@ -42,14 +46,18 @@ export async function team({ season, teamId }) {
 }
 
 export async function teams({ season }) {
-  if (isNaN(season)) {
+  if (season === 'current') {
     season = await getCurrentSeason();
   }
 
-  const [
-    seasonStartTimestamp,
-    seasonEndTimestamp,
-  ] = await getSeasonStartAndEndTimestamps(season);
+  let seasonStartTimestamp, seasonEndTimestamp;
+
+  if (season !== undefined) {
+    [
+      seasonStartTimestamp,
+      seasonEndTimestamp,
+    ] = await getSeasonStartAndEndTimestamps(season);
+  }
 
   return await prisma.team.findMany({
     where: {

--- a/lib/controllers/timeMap.js
+++ b/lib/controllers/timeMap.js
@@ -27,6 +27,8 @@ export async function getTimestampFromSeasonAndDay({ day, season }) {
 }
 
 export async function getFirstDayAndLastDayForSeason(season) {
+  const REGULAR_SEASON_PHASE_ID = 2;
+
   const result = await prisma.timeMap.aggregate({
     min: {
       day: true,
@@ -36,6 +38,8 @@ export async function getFirstDayAndLastDayForSeason(season) {
     },
     where: {
       season,
+      // Limit selection to regular season game days
+      phase_id: REGULAR_SEASON_PHASE_ID,
     },
   });
 

--- a/lib/routes/v2.js
+++ b/lib/routes/v2.js
@@ -1,7 +1,7 @@
 const Router = require('express-promise-router');
 
 const { playerStats } = require('../controllers/stats.js');
-const { players } = require('../controllers/players.js');
+const { player, players } = require('../controllers/players.js');
 const { team, teams } = require('../controllers/teams.js');
 
 const router = new Router();
@@ -65,7 +65,36 @@ router.get('/players', async (req, res) => {
 });
 
 /**
- * Get stats for players.
+ * Get a player's details. Defaults to retrieving most recent record.
+ *
+ * @route GET /players/:playerIdOrSlug
+ * @group Players
+ * @group APIv2
+ * @summary Get a player
+ * @returns {[object]} 200 - player
+ */
+router.get('/players/:playerIdOrSlug', async (req, res) => {
+  const playerIdOrSlug = req.params.playerIdOrSlug;
+
+  if (playerIdOrSlug === undefined) {
+    const err = new Error("Required query param 'playerIdOrSlug' missing.");
+    err.status = 400;
+    next(err);
+  }
+
+  // Attempt to retrieve player by the default 'player_id' field
+  let result = await player(playerIdOrSlug);
+
+  // If 'player_id' lookup returns null, attempt to find player by 'url_slug' field
+  if (result === null) {
+    result = await player(playerIdOrSlug, { findByField: 'url_slug' });
+  }
+
+  res.json(result);
+});
+
+/**
+ * Get stats for players and teams.
  *
  * @route GET /stats
  * @group Stats

--- a/lib/routes/v2.js
+++ b/lib/routes/v2.js
@@ -16,8 +16,15 @@ const router = new Router();
  * @returns {[object]} 200 - list of teams
  */
 router.get('/teams', async (req, res) => {
-  const season = Number(req.query.season);
+  let season;
 
+  if (req.query.season !== undefined) {
+    if (req.query.season === '' || req.query.season === 'current') {
+      season = 'current';
+    } else {
+      season = Number(req.query.season);
+    }
+  }
   const result = await teams({ season });
 
   res.json(result);
@@ -48,16 +55,24 @@ router.get('/teams/:teamId', async (req, res, next) => {
 });
 
 /**
- * Get all teams for a given season. Defaults to current season.
+ * Get a list of player details. Defaults to retrieving all players.
  *
  * @route GET /players
  * @group Players
  * @group APIv2
- * @summary Get the list of all players
+ * @summary Get the list of players
  * @returns {[object]} 200 - list of players
  */
 router.get('/players', async (req, res) => {
-  const season = Number(req.query.season);
+  let season;
+
+  if (req.query.season !== undefined) {
+    if (req.query.season === '' || req.query.season === 'current') {
+      season = 'current';
+    } else {
+      season = Number(req.query.season);
+    }
+  }
 
   const result = await players({ season });
 
@@ -99,19 +114,29 @@ router.get('/players/:playerIdOrSlug', async (req, res) => {
  * @route GET /stats
  * @group Stats
  * @group APIv2
- * @summary Get a list of player stats
- * @returns {[object]} 200 - list of player stats
+ * @summary Get a list of stat splits
+ * @returns {[object]} 200 - list of stat splits
  */
 router.get('/stats', async (req, res, next) => {
-  const { group, order, sortStat, teamId, type } = req.query;
+  const {
+    gameType,
+    group,
+    order,
+    playerId,
+    sortStat,
+    teamId,
+    type,
+  } = req.query;
   const limit =
     req.query.limit !== undefined ? Number(req.query.limit) : undefined;
   const season =
-    req.query.season !== undefined ? Number(req.query.season) : undefined;
+    req.query.season !== undefined && isNaN(req.query.season)
+      ? req.query.season
+      : Number(req.query.season);
 
   if (group === undefined) {
     const err = new Error(
-      'Required query param `group` missing. Available groups: hitting, pitching.'
+      "Required query param 'group' missing. Available groups: hitting, pitching."
     );
     err.status = 400;
     next(err);
@@ -126,9 +151,11 @@ router.get('/stats', async (req, res, next) => {
   }
 
   const result = await playerStats({
+    gameType,
     group,
     limit,
     order,
+    playerId,
     season,
     sortStat,
     teamId,

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "author": "Corvimae",
   "license": "MIT",
   "dependencies": {
-    "@prisma/client": "^2.12.1",
+    "@prisma/client": "^2.13.1",
     "core-js": "^3.6.5",
     "cors": "^2.8.5",
     "dotenv": "^8.2.0",
@@ -27,7 +27,7 @@
     "@babel/core": "^7.12.3",
     "@babel/node": "^7.12.1",
     "@babel/preset-env": "^7.12.1",
-    "@prisma/cli": "^2.12.1",
+    "@prisma/cli": "^2.13.1",
     "husky": ">=4",
     "lint-staged": ">=10",
     "nodemon": "^2.0.5",

--- a/prisma/.env.sample
+++ b/prisma/.env.sample
@@ -1,7 +1,0 @@
-# Environment variables declared in this file are automatically made available to Prisma.
-# See the documentation for more detail: https://pris.ly/d/prisma-schema#using-environment-variables
-
-# Prisma supports the native connection string format for PostgreSQL, MySQL and SQLite.
-# See the documentation for all the connection string options: https://pris.ly/d/connection-strings
-
-DATABASE_URL="postgresql://username:password@localhost:5432/database?schema=data"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -253,13 +253,17 @@ model Player {
   blood            String?
   url_slug         String?
 
-  current_location    String?
   current_state       String?
-  gameday_from        Int
-  gamestate_from      String
+  current_location    String?
+  debut_gameday       Int?
+  debut_season        Int?
+  debut_tournament    Int?
+  gameday_from        Int?
+  season_from         Int?
+  tournament_from     Int?
+  phase_type_from     String?
   position_id         Int?
   position_type       String?
-  season_from         Int
   team                String?
   team_abbreviation   String?
   team_id             String?
@@ -288,8 +292,8 @@ model Team {
   current_team_status String
   valid_from          DateTime
   valid_until         DateTime?
-  gameday_from        Int
-  season_from         Int
+  gameday_from        Int?
+  season_from         Int?
   division            String?
   division_id         String?
   league              String?
@@ -328,6 +332,7 @@ model PlayerBattingStatsSeason {
   slugging              Float?
   plate_appearances     Int
   at_bats               Int
+  hits                  Int
   walks                 Int
   singles               Int
   doubles               Int
@@ -351,16 +356,54 @@ model PlayerBattingStatsSeason {
   @@map("batting_stats_player_season")
 }
 
+// @View - Must be manually updated with every new Prisma introspection
+model PlayerBattingStatsPostseason {
+  player_id             String
+  player_name           String
+  team_id               String
+  team                  String
+  season                Int
+  batting_average       Float?
+  on_base_percentage    Float?
+  slugging              Float?
+  plate_appearances     Int
+  at_bats               Int
+  hits                  Int
+  walks                 Int
+  singles               Int
+  doubles               Int
+  triples               Int
+  // @TODO: Add quadruples to player batting stats postseason view
+  // quadruples            Int
+  home_runs             Int
+  runs_batted_in        Int
+  strikeouts            Int
+  sacrifices            Int
+  at_bats_risp          Int
+  hits_risps            Int
+  batting_average_risp  Float?
+  on_base_slugging      Float?
+  total_bases           Int
+  hbps                  Int
+  ground_outs           Int
+  flyouts               Int
+  gidps                 Int
+
+  @@id(fields: [player_id, season])
+  @@map("batting_stats_player_playoffs_season")
+}
+
 
 // @View - Must be manually updated with every new Prisma introspection
 model PlayerPitchingStatsSeason {
   player_id       String
   player_name     String
   season          Int
-  team_ids        String[]
+  team_id         String
   games           Int
   wins            Int
   losses          Int
+  win_pct         Float
   pitch_count     Int
   batters_faced   Int
   outs_recorded   Int
@@ -378,7 +421,43 @@ model PlayerPitchingStatsSeason {
   hits_per_9      Float
   k_per_9         Float
   hr_per_9        Float
+  whip            Float
+  k_bb            Float
 
   @@id(fields: [player_id, season])
   @@map("pitching_stats_player_season")
+}
+
+// @View - Must be manually updated with every new Prisma introspection
+model PlayerPitchingStatsPostseason {
+  player_id       String
+  player_name     String
+  season          Int
+  team_id         String
+  games           Int
+  wins            Int
+  losses          Int
+  win_pct         Float
+  pitch_count     Int
+  batters_faced   Int
+  outs_recorded   Int
+  innings         Int
+  runs_allowed    Int
+  shutouts        Int
+  quality_starts  Int
+  strikeouts      Int
+  walks           Int
+  hrs_allowed     Int
+  hits_allowed    Int
+  hbps            Float
+  era             Float
+  bb_per_9        Float
+  hits_per_9      Float
+  k_per_9         Float
+  hr_per_9        Float
+  whip            Float
+  k_bb            Float
+
+  @@id(fields: [player_id, season])
+  @@map("pitching_stats_player_playoffs_season")
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -878,30 +878,30 @@
   resolved "https://registry.yarnpkg.com/@prisma/bar/-/bar-0.0.1.tgz#088c4fbbb79c588391437ade9fd3a85527e753b3"
   integrity sha512-FVLhwVkbfhXlBhroWfIXMLi+3Jh9IEzYp+9z+MUUiw3ZsbcoAil7CN9/QIjHc4/TcCRyRfuSmT7qCnn4O+TjJw==
 
-"@prisma/cli@^2.12.1":
-  version "2.12.1"
-  resolved "https://registry.yarnpkg.com/@prisma/cli/-/cli-2.12.1.tgz#1f52ab2a363ae4cc88d4d18933bd304ed7f80612"
-  integrity sha512-obkwK95dEeifCdVehG0rS0BlPQGLsOtc9U1MgbrjNX3MnhXQdwROnvymfPB3DBlNyoLoHGklPgi9UlwBokNXcQ==
+"@prisma/cli@^2.13.1":
+  version "2.13.1"
+  resolved "https://registry.yarnpkg.com/@prisma/cli/-/cli-2.13.1.tgz#6af36f3e1a99852c6232202946043263a537cd95"
+  integrity sha512-1KIo29GFAM/oe56oVFB6SjLV+xaunBtcnln1v0KcSn0bx1MgdN00o0haB5qTqRwnqEMTqsS81zH8VwdIgQhn6A==
   dependencies:
     "@prisma/bar" "^0.0.1"
-    "@prisma/engines" "2.12.0-18.cf0680a1bfe8d5e743dc659cc7f08009f9587d58"
+    "@prisma/engines" "2.13.1-2.fcbc4bb2d306c86c28014f596b1e8c7980af8bd4"
 
-"@prisma/client@^2.12.1":
-  version "2.12.1"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.12.1.tgz#ff655c9cc1188035303f374d2f9f794b66fc18c7"
-  integrity sha512-HP4/E9sRdxw/FB7XP4EeRa5ri8Lp1U/L7G4VAA95aM8C+8ARioQHMNDpEjC83NrOrOr4EcaZV5pXDDQL1H+F0g==
+"@prisma/client@^2.13.1":
+  version "2.13.1"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.13.1.tgz#7379eeca980afc2fe64d2c745eb90480877f30f4"
+  integrity sha512-aD33DJpVHU3VqwDk5PEgnffbQeilUqmwVgqIxstVEiZ7TSs5oXQjwsSWAEfuvzPsR/rMJdeauAov58WHlMbVVA==
   dependencies:
-    "@prisma/engines-version" "2.12.0-18.cf0680a1bfe8d5e743dc659cc7f08009f9587d58"
+    "@prisma/engines-version" "2.13.1-2.fcbc4bb2d306c86c28014f596b1e8c7980af8bd4"
 
-"@prisma/engines-version@2.12.0-18.cf0680a1bfe8d5e743dc659cc7f08009f9587d58":
-  version "2.12.0-18.cf0680a1bfe8d5e743dc659cc7f08009f9587d58"
-  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-2.12.0-18.cf0680a1bfe8d5e743dc659cc7f08009f9587d58.tgz#428f8996f88c92a4142e35f196584a5e17c95871"
-  integrity sha512-IHb/Jag1Wmoq5tLZhOHP5zqLHEXqQEfrHb6l0drIBSvh2AF7yWQ3yyuD0ZEb1Nq37SvbBgop5wrWMOU8YWFTGQ==
+"@prisma/engines-version@2.13.1-2.fcbc4bb2d306c86c28014f596b1e8c7980af8bd4":
+  version "2.13.1-2.fcbc4bb2d306c86c28014f596b1e8c7980af8bd4"
+  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-2.13.1-2.fcbc4bb2d306c86c28014f596b1e8c7980af8bd4.tgz#9f5d48054aeeea0dfffeb45572aba7097e33c198"
+  integrity sha512-xMfD9iu03XSTgZqgWYqTnKYfmabjY+U2tj7ClA1WQqLziY0ZGI48tZQpNe6WGzv+6nVss3PpfHfkKlM0kzhZbw==
 
-"@prisma/engines@2.12.0-18.cf0680a1bfe8d5e743dc659cc7f08009f9587d58":
-  version "2.12.0-18.cf0680a1bfe8d5e743dc659cc7f08009f9587d58"
-  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-2.12.0-18.cf0680a1bfe8d5e743dc659cc7f08009f9587d58.tgz#0e23c811cfa2f58650bb3c04394b1ac0d9dac78a"
-  integrity sha512-F6RmUZ5JpPWxmGvVDji8c4gepHIGkvYbtuFi0IoDDJVaCVo8yS656stciKFyswI6/BLWXa0X47/MIMbz6nzw7g==
+"@prisma/engines@2.13.1-2.fcbc4bb2d306c86c28014f596b1e8c7980af8bd4":
+  version "2.13.1-2.fcbc4bb2d306c86c28014f596b1e8c7980af8bd4"
+  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-2.13.1-2.fcbc4bb2d306c86c28014f596b1e8c7980af8bd4.tgz#4a6aba46db9be442712e4b14b5a72e1da830e837"
+  integrity sha512-APwZRomHG94bOc3jY6kaoEOkVdavN859c5hCFOjhy014Uut8v5+dg1lz3RzUaiiSHK8NwgGKrO5rqO09yGu8Eg==
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"


### PR DESCRIPTION
Adds the `/v2/players/:playerIdOrSlug` endpoint for finding a player by either their ID or slug. This pull request also adds player postseason stats to the `/v2/stats` endpoint via the `gameType` parameter. Valid `gameType` options are `R` for regular season and `P` for postseason.