### PR TITLE
Add `/v2/stats/leaders`, `/v2/config`, and Prisma postinstall hook

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,4 +1,5 @@
 SIBR_PRODUCTION=0
+SIBR_API_SCHEME=http
 PGUSER=dbuser
 PGHOST=database.server.com
 PGPASSWORD=secretpassword

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Datablase requires some environmental variables to be set. A list of these varia
 
 ```
 SIBR_PRODUCTION=0
+SIBR_API_SCHEME=http
 PGUSER=dbuser
 PGHOST=database.server.com
 PGPASSWORD=secretpassword

--- a/lib/controllers/config.js
+++ b/lib/controllers/config.js
@@ -1,0 +1,382 @@
+import { seasons } from '../controllers/timeMap.js';
+
+export async function config() {
+  let config = {};
+
+  const sortedSeasonList = await seasons();
+
+  config.seasons = {
+    minSeason: sortedSeasonList[0].season,
+    maxSeason: sortedSeasonList[sortedSeasonList.length - 1].season,
+  };
+
+  config.gameTypes = [
+    {
+      label: 'Regular Season',
+      value: 'R',
+    },
+    {
+      label: 'Postseason',
+      value: 'P',
+    },
+  ];
+
+  config.columns = {
+    hitting: [
+      {
+        id: 'gamesPlayed',
+        label: 'Games Played',
+        labelBrief: 'G',
+        dataField: 'games_played',
+        description: '',
+      },
+      {
+        id: 'atBats',
+        label: 'At Bats',
+        labelBrief: 'AB',
+        dataField: 'at_bats',
+        description: '',
+      },
+      {
+        id: 'runsScored',
+        label: 'Runs Scored',
+        labelBrief: 'R',
+        dataField: 'runs_scored',
+        description: '',
+      },
+      {
+        id: 'hits',
+        label: 'Hits',
+        labelBrief: 'H',
+        dataField: 'hits',
+        description: '',
+      },
+      {
+        id: 'doublesHit',
+        label: 'Doubles Hit',
+        labelBrief: '2B',
+        dataField: 'doubles',
+        description: '',
+      },
+      {
+        id: 'triplesHit',
+        label: 'Triples Hit',
+        labelBrief: '3B',
+        dataField: 'triples',
+        description: '',
+      },
+      {
+        id: 'quadruplesHit',
+        label: 'Quadruples Hit',
+        labelBrief: '4B',
+        dataField: 'quadruples',
+        description: '',
+      },
+      {
+        id: 'runsBattedIn',
+        label: 'Runs Batted In',
+        labelBrief: 'RBI',
+        dataField: 'runs_batted_in',
+        description: '',
+      },
+      {
+        id: 'stolenBases',
+        label: 'Stolen Bases',
+        labelBrief: 'SB',
+        dataField: 'stolen_bases',
+        description: '',
+      },
+      {
+        id: 'caughtStealing',
+        label: 'Caught Stealing',
+        labelBrief: 'CS',
+        dataField: 'caught_stealing',
+        description: '',
+      },
+      {
+        id: 'basesOnBalls',
+        label: 'Bases on Balls (Walks)',
+        labelBrief: 'BB',
+        dataField: 'walks',
+        description: '',
+      },
+      {
+        id: 'strikeouts',
+        label: 'Strikeouts',
+        labelBrief: 'SO',
+        dataField: 'strikeouts',
+        description: '',
+      },
+      {
+        id: 'battingAverage',
+        label: 'Batting Average',
+        labelBrief: 'BA',
+        dataField: 'batting_average',
+        description: '',
+      },
+      {
+        id: 'battingAverageWithRunnersInScoringPosition',
+        label: 'Batting Average With Runners in Scoring Position',
+        labelBrief: 'BA/RISP',
+        dataField: 'batting_average_risp',
+        description: '',
+      },
+      {
+        id: 'hitsWithRunnersInScoringPosition',
+        label: 'Hits With Runners in Scoring Position',
+        labelBrief: 'HRISP',
+        dataField: 'hits_risp',
+        description: '',
+      },
+      {
+        id: 'onBasePercentage',
+        label: 'On-base Percentage',
+        labelBrief: 'OBP',
+        dataField: 'on_base_percentage',
+        description: '',
+      },
+      {
+        id: 'sluggingPercentage',
+        label: 'Slugging Percentage',
+        labelBrief: 'SLG',
+        dataField: 'slugging',
+        description: '',
+      },
+      {
+        id: 'onBasePlusSlugging',
+        label: 'On-base Plus Slugging Percentage',
+        labelBrief: 'OPS',
+        dataField: 'on_base_slugging',
+        description: '',
+      },
+      {
+        id: 'totalBases',
+        label: 'Total Bases',
+        labelBrief: 'TB',
+        dataField: 'total_bases',
+        description: '',
+      },
+      {
+        id: 'groundIntoDoublePlays',
+        label: 'Double Plays Grounded Into',
+        labelBrief: 'GDP',
+        dataField: 'gidp',
+        description: '',
+      },
+      {
+        id: 'sacrifices',
+        label: 'Sacrifices',
+        labelBrief: 'SAC',
+        dataField: 'sacrifices',
+        description: '',
+      },
+      {
+        id: 'sacrificeBunts',
+        label: 'Sacrifice Hits (Sacrifice Bunts)',
+        labelBrief: 'SH',
+        dataField: 'sacrifice_bunts',
+        description: '',
+      },
+      {
+        id: 'sacrificeFlies',
+        label: 'Sacrifice Flies',
+        labelBrief: 'SF',
+        dataField: 'sacrifice_flies',
+        description: '',
+      },
+      {
+        id: 'homeRuns',
+        label: 'Home Runs',
+        labelBrief: 'HR',
+        dataField: 'home_runs',
+        description: '',
+      },
+      {
+        id: 'hitByPitch',
+        label: 'Hit-by-Pitch',
+        labelBrief: 'HBP',
+        dataField: 'hit_by_pitches',
+        description: '',
+      },
+    ],
+    pitching: [
+      {
+        id: 'wins',
+        label: 'Wins',
+        labelBrief: 'W',
+        dataField: 'wins',
+        description: '',
+      },
+      {
+        id: 'losses',
+        label: 'Losses',
+        labelBrief: 'L',
+        dataField: 'losses',
+        description: '',
+      },
+      {
+        id: 'winningPercentage',
+        label: 'Winning Percentage',
+        labelBrief: 'W-L%',
+        dataField: 'win_pct',
+        description: '',
+      },
+      {
+        id: 'earnedRunAverage',
+        label: 'Earned Run Average',
+        labelBrief: 'ERA',
+        dataField: 'earned_run_average',
+        description: '',
+      },
+
+      {
+        id: 'gamesPlayed',
+        label: 'Games Played',
+        labelBrief: 'G',
+        dataField: 'games',
+        description: '',
+      },
+      {
+        id: 'shutouts',
+        label: 'Shutouts',
+        labelBrief: 'SHO',
+        dataField: 'shutouts',
+        description: '',
+      },
+      {
+        id: 'inningsPitched',
+        label: 'Innings Pitched',
+        labelBrief: 'IP',
+        dataField: 'innings',
+        description: '',
+      },
+      {
+        id: 'hitsAllowed',
+        label: 'Hits Allowed',
+        labelBrief: 'H',
+        dataField: 'hits_allowed',
+        description: '',
+      },
+      {
+        id: 'earnedRuns',
+        label: 'Earned Runs',
+        labelBrief: 'R',
+        dataField: 'runs_allowed',
+        description: '',
+      },
+      {
+        id: 'homeRuns',
+        label: 'Home Runs',
+        labelBrief: 'HR',
+        dataField: 'home_runs_allowed',
+        description: '',
+      },
+      {
+        id: 'basesOnBalls',
+        label: 'Bases on Balls (Walks)',
+        labelBrief: 'BB',
+        dataField: 'walks',
+        description: '',
+      },
+      {
+        id: 'strikeouts',
+        label: 'Strikeouts',
+        labelBrief: 'SO',
+        dataField: 'strikeouts',
+        description: '',
+      },
+      {
+        id: 'qualityStarts',
+        label: 'Quality Starts',
+        labelBrief: 'QS',
+        dataField: 'quality_starts',
+        description: '',
+      },
+      {
+        id: 'battersFaced',
+        label: 'Batters Faced',
+        labelBrief: 'BF',
+        dataField: 'batters_faced',
+        description: '',
+      },
+      {
+        id: 'walksAndHitsPerInningPitched',
+        label: 'Walks and Hits Per Inning Pitched',
+        labelBrief: 'WHIP',
+        dataField: 'whip',
+        description: '',
+      },
+      {
+        id: 'hitsAllowedPerNine',
+        label: 'Hits Per 9 Innings',
+        labelBrief: 'H9',
+        dataField: 'hits_per_9',
+        description: '',
+      },
+      {
+        id: 'homeRunsPerNine',
+        label: 'Home Runs Per 9 Innings',
+        labelBrief: 'HR9',
+        dataField: 'home_runs_per_9',
+        description: '',
+      },
+      {
+        id: 'basesOnBallsPerNine',
+        label: 'Walks Per 9 Innings',
+        labelBrief: 'BB9',
+        dataField: 'walks_per_9',
+        description: '',
+      },
+      {
+        id: 'strikeoutsPerNine',
+        label: 'Strikeouts Per 9 Innings',
+        labelBrief: 'SO9',
+        dataField: 'strikeouts_per_9',
+        description: '',
+      },
+      {
+        id: 'strikeoutToWalkRatio',
+        label: 'Strikeout-to-Walk Ratio',
+        labelBrief: 'SO/BB',
+        dataField: 'strikeouts_per_walk',
+        description: '',
+      },
+      {
+        id: 'hitBatsmen',
+        label: 'Hit Batsmen',
+        labelBrief: 'HB',
+        dataField: 'hit_by_pitches',
+        description: '',
+      },
+      {
+        id: 'numberOfPitches',
+        label: 'Number of Pitches',
+        labelBrief: 'NP',
+        dataField: 'pitches_thrown',
+        description: '',
+      },
+      {
+        id: 'strikePercentage',
+        label: 'Strike Percentage',
+        labelBrief: 'STRIKE%',
+        dataField: 'strikeout_percentage',
+        description: '',
+      },
+      {
+        id: 'walkPercentage',
+        label: 'Walk Percentage',
+        labelBrief: 'BB%',
+        dataField: 'walk_percentage',
+        description: '',
+      },
+    ],
+  };
+
+  config.defaults = {
+    gameType: 'R',
+    season: config.seasons.maxSeason,
+    statType: 'season',
+  };
+
+  return config;
+}

--- a/lib/controllers/players.js
+++ b/lib/controllers/players.js
@@ -6,13 +6,17 @@ import {
 
 const prisma = new PrismaClient();
 
-export async function players({ season }) {
+export async function players({
+  order = 'desc',
+  playerPool,
+  season,
+  sortField,
+}) {
   if (season === 'current') {
     season = await getCurrentSeason();
   }
 
   let seasonStartTimestamp, seasonEndTimestamp;
-
   if (season !== undefined) {
     [
       seasonStartTimestamp,
@@ -20,8 +24,35 @@ export async function players({ season }) {
     ] = await getSeasonStartAndEndTimestamps(season);
   }
 
+  // @TODO: Add rookie and active player pools
+  let playerPoolFilter = {};
+  switch (playerPool) {
+    case 'deceased':
+      playerPoolFilter = {
+        current_state: 'deceased',
+        // Exclude incinerations not attributed to an event
+        // @TODO: Workaround until 'nulls last' is implemented for sorts
+        NOT: {
+          incineration_phase: null,
+        },
+      };
+      break;
+    case 'all':
+    default:
+      break;
+  }
+
+  // Allow multiple sort fields
+  let sortFilters = [];
+  if (sortField !== undefined) {
+    for (let field of sortField.split(',')) {
+      sortFilters.push({ [field]: order });
+    }
+  }
+
   return await prisma.player.findMany({
     where: {
+      ...playerPoolFilter,
       valid_from: {
         lte: seasonStartTimestamp,
       },
@@ -37,6 +68,7 @@ export async function players({ season }) {
       ],
     },
     orderBy: [
+      ...sortFilters,
       {
         season_from: 'desc',
       },
@@ -63,40 +95,5 @@ export async function player(playerId, { findByField = 'player_id' } = {}) {
       valid_from: 'desc',
     },
     distinct: ['player_id'],
-  });
-}
-
-export async function deceasedPlayers() {
-  return await prisma.player.findMany({
-    where: {
-      deceased: true,
-      valid_until: null,
-    },
-    orderBy: {
-      player_name: 'asc',
-    },
-  });
-}
-
-async function playerIdBySlug(slug) {
-  // Get the first record with the given url_slug
-  return await prisma.player.findFirst({
-    select: {
-      player_id: true,
-    },
-    where: {
-      player_url_slug: slug,
-    },
-  });
-}
-
-export async function playerInfoCurrent(playerIds) {
-  return await prisma.player.findMany({
-    where: {
-      player_id: {
-        in: playerIds,
-      },
-      valid_until: null,
-    },
   });
 }

--- a/lib/controllers/stats.js
+++ b/lib/controllers/stats.js
@@ -4,8 +4,67 @@ import { getSeasonStartAndEndTimestamps } from '../controllers/timeMap.js';
 
 const prisma = new PrismaClient();
 
+// @TODO: Add stat leader limit, leaderCategories filters
+// @TODO: Replace ref_leaderboard database functions
+// @TODO: Add all-time and single season leaders
+export async function statLeaders({ group, season, type = 'season' } = {}) {
+  if (type === 'season' && season === 'current') {
+    season = await getCurrentSeason();
+  }
+
+  const statGroups = group.split(',');
+
+  let response = [];
+
+  for (const statGroup of statGroups) {
+    let statGroupResult = {};
+    let leaders;
+
+    if (type === 'season') {
+      if (statGroup === 'hitting') {
+        leaders = await prisma.$queryRaw`SELECT * FROM ref_leaderboard_season_batting(${season})`;
+      } else if (statGroup === 'pitching') {
+        leaders = await prisma.$queryRaw`SELECT * FROM ref_leaderboard_season_pitching(${season})`;
+      }
+    }
+
+    const leaderCategories = leaders.reduce((accumulator, currentValue) => {
+      const { stat: currentStatCategory, ...leader } = currentValue;
+
+      let leaderCategory = accumulator.find(
+        (category) => category.leaderCategory === currentValue.stat
+      );
+
+      if (leaderCategory === undefined) {
+        leaderCategory = {
+          leaderCategory: currentStatCategory,
+          leaders: [],
+        };
+
+        accumulator.push(leaderCategory);
+      }
+
+      if (type === 'season') {
+        leader.season = season;
+      }
+
+      leaderCategory.leaders.push(leader);
+
+      return accumulator;
+    }, []);
+
+    statGroupResult.leaderCategories = leaderCategories;
+    statGroupResult.statGroup = statGroup;
+
+    response.push(statGroupResult);
+  }
+
+  return response;
+}
+
 // @TODO: Add explicit types for career, single season, single game, etc
 export async function playerStats({
+  fields,
   gameType = 'R',
   group,
   limit,
@@ -51,16 +110,37 @@ export async function playerStats({
       );
     }
 
+    const orderByDefaults = [
+      {
+        season: 'asc',
+      },
+    ];
+
     const viewResults = await view.findMany({
+      select:
+        fields !== undefined
+          ? fields.reduce(
+              (accumulator, field) => {
+                return { ...accumulator, [field]: true };
+              },
+              {
+                player_id: true,
+                player_name: true,
+                season: true,
+                team_id: true,
+              }
+            )
+          : undefined,
       where: {
         season,
         player_id: playerId,
         team_id: teamId,
       },
       take: limit,
-      orderBy: {
-        [sortStat]: order,
-      },
+      orderBy:
+        sortStat !== undefined
+          ? orderByDefaults.unshift({ [sortStat]: order })
+          : orderByDefaults,
     });
 
     statGroupResult.group = statGroup;

--- a/lib/controllers/teams.js
+++ b/lib/controllers/teams.js
@@ -6,7 +6,7 @@ import {
 
 const prisma = new PrismaClient();
 
-export async function team({ season, teamId }) {
+export async function team({ findByField = 'team_id', season, teamId } = {}) {
   if (season === 'current') {
     season = await getCurrentSeason();
   }
@@ -22,7 +22,7 @@ export async function team({ season, teamId }) {
 
   return await prisma.team.findFirst({
     where: {
-      team_id: teamId,
+      [findByField]: teamId,
       valid_from: {
         lte: seasonStartTimestamp,
       },

--- a/lib/controllers/timeMap.js
+++ b/lib/controllers/timeMap.js
@@ -2,6 +2,8 @@ const { PrismaClient } = require('@prisma/client');
 
 const prisma = new PrismaClient();
 
+const REGULAR_SEASON_PHASE_ID = 2;
+
 export async function getCurrentSeason() {
   const currentSeason = await prisma.timeMap.aggregate({
     max: {
@@ -27,8 +29,6 @@ export async function getTimestampFromSeasonAndDay({ day, season }) {
 }
 
 export async function getFirstDayAndLastDayForSeason(season) {
-  const REGULAR_SEASON_PHASE_ID = 2;
-
   const result = await prisma.timeMap.aggregate({
     min: {
       day: true,
@@ -38,7 +38,6 @@ export async function getFirstDayAndLastDayForSeason(season) {
     },
     where: {
       season,
-      // Limit selection to regular season game days
       phase_id: REGULAR_SEASON_PHASE_ID,
     },
   });
@@ -59,4 +58,22 @@ export async function getSeasonStartAndEndTimestamps(season) {
   });
 
   return [firstDayTimestamp, lastDayTimestamp];
+}
+
+// Get a sorted list of regular seasons found in timeMap
+export async function seasons() {
+  const seasons = await prisma.timeMap.findMany({
+    where: {
+      phase_id: REGULAR_SEASON_PHASE_ID,
+    },
+    select: {
+      season: true,
+    },
+    orderBy: {
+      season: 'asc',
+    },
+    distinct: ['season'],
+  });
+
+  return seasons;
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,9 +22,11 @@ expressSwagger({
       'SIBR_API_HOST' in process.env
         ? process.env.SIBR_API_HOST
         : 'api.blaseball-reference.com',
-    basePath: '/v1',
+    basePath: '/',
     produces: ['application/json'],
-    schemes: ['https'],
+    schemes: [
+      'SIBR_API_SCHEME' in process.env ? process.env.SIBR_API_SCHEME : 'https',
+    ],
   },
   basedir: __dirname,
   files: ['./routes/**/*.js'],

--- a/lib/routes/v1.js
+++ b/lib/routes/v1.js
@@ -142,7 +142,7 @@ function addRoute(router, endpoint, method, queryAccessor) {
  * Download all of the game events, base runners, and player events. Child data (base runners, player events) are
  * provided as their own lists and are not mapped into their parents, and thus must be matched by `game_event_id`.
  *
- * @route GET /data/events
+ * @route GET /v1/data/events
  * @group Raw Data
  * @summary Download all raw event data.
  * @param {number} season.query  - season to get event data for (zero-indexed)
@@ -215,7 +215,7 @@ const VALID_SORT_COLUMNS = [
 /**
  * Get the list of game events that match the query. One of `playerId`, `gameId`, `pitcherId`, `batterId` must be specified.
  *
- * @route GET /events
+ * @route GET /v1/events
  * @group Game Events
  * @summary Query for game events.
  * @param {string} playerId.query - The ID of a player that must be the batter or the pitcher in each event.
@@ -371,7 +371,7 @@ router.get('/events', async (req, res) => {
 /**
  * Get the number of events for a batter or pitcher with a certain `event_type`.
  *
- * @route GET /countByType
+ * @route GET /v1/countByType
  * @group Game Events
  * @summary Calculate the number of events for each batter or pitcher.
  * @param {string} eventType.query.required - The type of event to count.
@@ -403,7 +403,7 @@ router.get('/countByType', async (req, res) => {
 /**
  * Get all currently decieased players
  *
- * @route GET /deceased
+ * @route GET /v1/deceased
  * @group Players
  * @summary Get a list of all currently deceased players
  * @returns {[object]} 200 - Array of player objects
@@ -415,7 +415,7 @@ router.get('/deceased', async (req, res) => {
 /**
  * Get all player IDs matching a given name
  *
- * @route GET /playerIdsByName
+ * @route GET /v1/playerIdsByName
  * @group Players
  * @summary Get all player IDs matching a given player name
  * @param {string} name.query - The name of the player
@@ -440,7 +440,7 @@ router.get('/playerIdsByName', async (req, res) => {
 /**
  * Get extended player info for a given player, given a player id, name, or slug.
  *
- * @route GET /playerInfo
+ * @route GET /v1/playerInfo
  * @group Players
  * @summary Get extended info for a given player - their name, attributes, ratings, and stars
  * @param {string} playerId.query - The player ID of the player (takes precedence if other params are specified)
@@ -494,7 +494,7 @@ router.get('/playerInfo', async (req, res) => {
 /**
  * Get the list of all players currently tagged with some kind of modification (like SHELLED)
  *
- * @route GET /taggedPlayers
+ * @route GET /v1/taggedPlayers
  * @group Players
  * @summary Get the list of all players with a modification tag
  * @returns {object} 200 - array of player information including current team id/nickname
@@ -506,7 +506,7 @@ router.get('/taggedPlayers', async (req, res) => {
 /**
  * Get the current roster for a given team, using either ID or slug.
  *
- * @route GET /currentRoster
+ * @route GET /v1/currentRoster
  * @group Teams
  * @summary Get the current roster for a given team
  * @param {string} teamId.query - The ID of the team (takes precedence if slug is given)
@@ -536,7 +536,7 @@ router.get('/currentRoster', async (req, res) => {
 /**
  * Get the current list of all known players
  *
- * @route GET /allPlayers
+ * @route GET /v1/allPlayers
  * @group Players
  * @summary Get the list of all current players, optionally including players in the Shadows
  * @param {boolean} includeShadows.query - whether to include players in the Shadows
@@ -551,7 +551,7 @@ router.get('/allPlayers', async (req, res) => {
 /**
  * Get the list of all players and their data as of a specific Season and Gameday
  *
- * @route GET /allPlayersForGameday
+ * @route GET /v1/allPlayersForGameday
  * @group Players
  * @param {number} season.query - Season to query (zero-indexed)
  * @param {number} day.query - Day to query (zero-indexed)
@@ -567,7 +567,7 @@ router.get('/allPlayersForGameday', async (req, res) => {
 /**
  * Get all current teams
  *
- * @route GET /allTeams
+ * @route GET /v1/allTeams
  * @group Teams
  * @summary Get the list of all current teams
  * @returns {[object]} 200 - list of current teams
@@ -581,7 +581,7 @@ router.get('/allTeams', async (req, res) => {
 /**
  * Get current star values for all teams
  *
- * @route GET /allTeamStars
+ * @route GET /v1/allTeamStars
  * @group Teams
  * @summary Get current star values for all teams
  * @returns {[object]} 200 - list of current team stars
@@ -593,8 +593,8 @@ router.get('/allTeamStars', async (req, res) => {
 /**
  * Get the season leaders for a given category and stat
  *
- * @route GET /seasonLeaders
- * @group Statistics v2
+ * @route GET /v1/seasonLeaders
+ * @group Statistics
  * @summary Get the season leaders for a given category and stat
  * @param {number} season.query - Season to query (zero-indexed)
  * @param {string} category.query - Stat category (batting, pitching, running, or fielding)
@@ -638,8 +638,8 @@ router.get('/seasonLeaders', async (req, res) => {
 /**
  * Get performance statistics for a given list of players
  *
- * @route GET /playerStats
- * @group Statistics v2
+ * @route GET /v1/playerStats
+ * @group Statistics
  * @summary Get categorical statistics for the given players
  * @param {string} category.query - either 'batting' or 'pitching'
  * @param {number} season.query - (optional) season to get stats for
@@ -705,7 +705,7 @@ router.get('/playerStats', async (req, res) => {
 /**
  * Get the number of plate appearances for each historical batter. If `batterId` is specified, only that batter is returned.
  *
- * @route GET /plateAppearances
+ * @route GET /v1/plateAppearances
  * @group Statistics (deprecated)
  * @summary Calculate plate appearances for each batter.
  * @param {string} batterId.query - The ID of the batter by which to filter.
@@ -716,7 +716,7 @@ addRoute(router, '/plateAppearances', plateAppearances, 'batterId');
 /**
  * Get the number of at-bats for each historical batter. If `batterId` is specified, only that batter is returned.
  *
- * @route GET /atBats
+ * @route GET /v1/atBats
  * @group Statistics (deprecated)
  * @summary Calculate at-bats for each batter.
  * @param {string} batterId.query - The ID of the batter by which to filter.
@@ -727,7 +727,7 @@ addRoute(router, '/atBats', atBats, 'batterId');
 /**
  * Get the number of hits for each historical batter. If `batterId` is specified, only that batter is returned.
  *
- * @route GET /hits
+ * @route GET /v1/hits
  * @group Statistics (deprecated)
  * @summary Calculate number of hits for each batter.
  * @param {string} batterId.query - The ID of the batter by which to filter.
@@ -738,7 +738,7 @@ addRoute(router, '/hits', hits, 'batterId');
 /**
  * Get the number of times each historical batter got on base. If `batterId` is specified, only that batter is returned.
  *
- * @route GET /timesOnBase
+ * @route GET /v1/timesOnBase
  * @group Statistics (deprecated)
  * @summary Calculate number of times on base for each batter.
  * @param {string} batterId.query - The ID of the batter by which to filter.
@@ -749,7 +749,7 @@ addRoute(router, '/timesOnBase', timesOnBase, 'batterId');
 /**
  * Get the batting average (BA) for each historical batter. If `batterId` is specified, only that batter is returned.
  *
- * @route GET /battingAverage
+ * @route GET /v1/battingAverage
  * @group Statistics (deprecated)
  * @summary Calculate batting average of each batter.
  * @param {string} batterId.query - The ID of the batter by which to filter.
@@ -760,7 +760,7 @@ addRoute(router, '/battingAverage', battingAverage, 'batterId');
 /**
  * Get the on-base percentage (OBP) for each historical batter. If `batterId` is specified, only that batter is returned.
  *
- * @route GET /onBasePercentage
+ * @route GET /v1/onBasePercentage
  * @group Statistics (deprecated)
  * @summary Calculate OBP of each batter.
  * @param {string} batterId.query - The ID of the batter by which to filter.
@@ -771,7 +771,7 @@ addRoute(router, '/onBasePercentage', onBasePercentage, 'batterId');
 /**
  * Get on-base percentage plus slugging (OPS) for each historical batter. If `batterId` is specified, only that batter is returned.
  *
- * @route GET /onBasePlusSlugging
+ * @route GET /v1/onBasePlusSlugging
  * @group Statistics (deprecated)
  * @summary Calculate OPS of each batter.
  * @param {string} batterId.query - The ID of the batter by which to filter.
@@ -782,7 +782,7 @@ addRoute(router, '/onBasePlusSlugging', onBasePlusSlugging, 'batterId');
 /**
  * Get the slugging percentage (SLG) for each historical batter. If `batterId` is specified, only that batter is returned.
  *
- * @route GET /slugging
+ * @route GET /v1/slugging
  * @group Statistics (deprecated)
  * @summary Calculate SLG of each batter.
  * @param {string} batterId.query - The ID of the batter by which to filter.
@@ -793,7 +793,7 @@ addRoute(router, '/slugging', slugging, 'batterId');
 /**
  * Get the number of outs recorded by each historical pitcher. If `pitcherId` is specified, only that pitcher is returned.
  *
- * @route GET /outsRecorded
+ * @route GET /v1/outsRecorded
  * @group Statistics (deprecated)
  * @summary Calculate number of outs recorded by each pitcher.
  * @param {string} pitcherId.query - The ID of the pitcher by which to filter.
@@ -804,7 +804,7 @@ addRoute(router, '/outsRecorded', outsRecorded, 'pitcherId');
 /**
  * Get the number of hits recorded by each historical pitcher. If `pitcherId` is specified, only that pitcher is returned.
  *
- * @route GET /hitsRecorded
+ * @route GET /v1/hitsRecorded
  * @group Statistics (deprecated)
  * @summary Calculate number of hits recorded by each pitcher.
  * @param {string} pitcherId.query - The ID of the pitcher by which to filter.
@@ -815,7 +815,7 @@ addRoute(router, '/hitsRecorded', hitsRecorded, 'pitcherId');
 /**
  * Get the number of walks recorded by each historical pitcher. If `pitcherId` is specified, only that pitcher is returned.
  *
- * @route GET /walksRecorded
+ * @route GET /v1/walksRecorded
  * @group Statistics (deprecated)
  * @summary Calculate number of walks recorded by each pitcher.
  * @param {string} pitcherId.query - The ID of the pitcher by which to filter.
@@ -828,7 +828,7 @@ addRoute(router, '/walksRecorded', walksRecorded, 'pitcherId');
  *
  * TODO: Not currently implemented.
  *
- * @route GET /earnedRuns
+ * @route GET /v1/earnedRuns
  * @group Statistics (deprecated)
  * @summary Calculate the number of runs earned by each pitcher.
  * @param {string} pitcherId.query - The ID of the pitcher by which to filter.
@@ -840,7 +840,7 @@ addRoute(router, '/earnedRuns', earnedRuns, 'pitcherId');
  * Get the number of walks and hits per inning pitched (WHIP) for each historical pitcher.
  * If `pitcherId` is specified, only that pitcher is returned.
  *
- * @route GET /whip
+ * @route GET /v1/whip
  * @group Statistics (deprecated)
  * @summary Calculate WHIP of each pitcher.
  * @param {string} pitcherId.query - The ID of the pitcher by which to filter.
@@ -857,7 +857,7 @@ router.post('/brewCoffee', (req, res) => {
  * Get the earned run average (ERA) for each historical pitcher.
  * If `pitcherId` is specified, only that pitcher is returned.
  *
- * @route GET /era
+ * @route GET /v1/era
  * @group Statistics (deprecated)
  * @summary Calculate ERA of each pitcher.
  * @param {string} pitcherId.query - The ID of the pitcher by which to filter.

--- a/lib/routes/v2.js
+++ b/lib/routes/v2.js
@@ -34,23 +34,39 @@ router.get('/teams', async (req, res) => {
 /**
  * Get a single team's details for a given season. Defaults to current season.
  *
- * @route GET /teams/:teamId
+ * @route GET /teams/:teamIdOrSlug
  * @group Teams
  * @group APIv2
  * @summary Get a specific team's details
  * @returns {[object]} 200 - a team's details
  */
-router.get('/teams/:teamId', async (req, res, next) => {
-  const season = Number(req.query.season);
-  const teamId = req.params.teamId;
+router.get('/teams/:teamIdOrSlug', async (req, res, next) => {
+  const teamIdOrSlug = req.params.teamIdOrSlug;
 
-  if (teamId === undefined) {
-    const err = new Error('Required query param `teamId` missing');
+  if (teamIdOrSlug === undefined) {
+    const err = new Error('Required query param `teamIdOrSlug` missing');
     err.status = 400;
     next(err);
   }
 
-  const result = await team({ season, teamId });
+  const season =
+    req.query.season !== undefined
+      ? isNaN(req.query.season)
+        ? req.query.season
+        : Number(req.query.season)
+      : undefined;
+
+  // Attempt to retrieve team by the default 'team_id' field
+  let result = await team({ season, teamId: teamIdOrSlug });
+
+  // If 'team_id' lookup returns null, attempt to find team by 'url_slug' field
+  if (result === null) {
+    result = await team({
+      findByField: 'url_slug',
+      season,
+      teamId: teamIdOrSlug,
+    });
+  }
 
   res.json(result);
 });
@@ -65,17 +81,15 @@ router.get('/teams/:teamId', async (req, res, next) => {
  * @returns {[object]} 200 - list of players
  */
 router.get('/players', async (req, res) => {
-  let season;
+  const season =
+    req.query.season !== undefined
+      ? isNaN(req.query.season)
+        ? req.query.season
+        : Number(req.query.season)
+      : undefined;
+  const { order, playerPool, sortField } = req.query;
 
-  if (req.query.season !== undefined) {
-    if (req.query.season === '' || req.query.season === 'current') {
-      season = 'current';
-    } else {
-      season = Number(req.query.season);
-    }
-  }
-
-  const result = await players({ season });
+  const result = await players({ order, playerPool, season, sortField });
 
   res.json(result);
 });

--- a/lib/routes/v2.js
+++ b/lib/routes/v2.js
@@ -10,10 +10,10 @@ const router = new Router();
 /**
  * Get all teams for a given season. Defaults to current season.
  *
- * @route GET /teams
+ * @route GET /v2/teams
  * @group Teams
  * @group APIv2
- * @summary Get the list of all teams
+ * @param {string} season.query - The (0-indexed) Blaseball season (or `current` for current season).
  * @returns {[object]} 200 - list of teams
  */
 router.get('/teams', async (req, res) => {
@@ -34,10 +34,11 @@ router.get('/teams', async (req, res) => {
 /**
  * Get a single team's details for a given season. Defaults to current season.
  *
- * @route GET /teams/:teamIdOrSlug
+ * @route GET /v2/teams/:teamIdOrSlug
  * @group Teams
  * @group APIv2
- * @summary Get a specific team's details
+ * @param {string} teamIdOrSlug.query.required - The team ID or URL slug.
+ * @param {string} season.query - The (0-indexed) Blaseball season.
  * @returns {[object]} 200 - a team's details
  */
 router.get('/teams/:teamIdOrSlug', async (req, res, next) => {
@@ -74,10 +75,13 @@ router.get('/teams/:teamIdOrSlug', async (req, res, next) => {
 /**
  * Get a list of player details. Defaults to retrieving all players.
  *
- * @route GET /players
+ * @route GET /v2/players
  * @group Players
  * @group APIv2
- * @summary Get the list of players
+ * @param {string} season.query - The (0-indexed) Blaseball season (or `current` for current season).
+ * @param {string} playerPool.query - The pool of players to return (e.g. `deceased`, `rookies`).
+ * @param {string} sortField.query - The column to sort players by.
+ * @param {string} order.query - The order of the sortField (`asc` or `desc`).
  * @returns {[object]} 200 - list of players
  */
 router.get('/players', async (req, res) => {
@@ -97,10 +101,10 @@ router.get('/players', async (req, res) => {
 /**
  * Get a player's details. Defaults to retrieving most recent record.
  *
- * @route GET /players/:playerIdOrSlug
+ * @route GET /v2/players/:playerIdOrSlug
  * @group Players
  * @group APIv2
- * @summary Get a player
+ * @param {string} playerIdOrSlug.query.required - The player ID or URL slug.
  * @returns {[object]} 200 - player
  */
 router.get('/players/:playerIdOrSlug', async (req, res) => {
@@ -126,10 +130,19 @@ router.get('/players/:playerIdOrSlug', async (req, res) => {
 /**
  * Get stats for players and teams.
  *
- * @route GET /stats
+ * @route GET /v2/stats
  * @group Stats
  * @group APIv2
- * @summary Get a list of stat splits
+ * @param {string} type.query.required - The type of stat split (defaults to `season`).
+ * @param {string} group.query.required - The stat groups to return (e.g. `hitting,pitching` or `hitting`).
+ * @param {string} fields.query - The stat fields to return (e.g. `strikeouts,home_runs` or `home_runs`).
+ * @param {string} season.query - The (0-indexed) Blaseball season (or `current` for current season).
+ * @param {string} gameType.query - The type of game (e.g. `R` for regular season, `P` for postseason).
+ * @param {string} sortStat.query - The stat field to sort on.
+ * @param {string} order.query - The order of the sorted stat field.
+ * @param {string} playerId.query - The ID of a player.
+ * @param {string} teamId.query - The ID of a team to retrieve player stats for.
+ * @param {string} limit.query - The number of rows to return for each field (e.g. `5`).
  * @returns {[object]} 200 - list of stat splits
  */
 router.get('/stats', async (req, res, next) => {
@@ -188,20 +201,15 @@ router.get('/stats', async (req, res, next) => {
 /**
  * Get stats for players and teams.
  *
- * @route GET /stats/leaders
+ * @route GET /v2/stats/leaders
  * @group Stat Leaders
  * @group APIv2
- * @summary Get a list of stat leader splits
+ * @param {string} season.query.required - The (0-indexed) Blaseball season (or `current` for current season).
+ * @param {string} group.query.required - The stat groups to return (e.g. `hitting,pitching` or `hitting`).
  * @returns {[object]} 200 - list of stat leader splits
  */
 router.get('/stats/leaders', async (req, res, next) => {
   const { group } = req.query;
-  const leaderCategories =
-    req.query.leaderCategories !== undefined
-      ? req.query.leaderCategories.split(',')
-      : undefined;
-  const limit =
-    req.query.limit !== undefined ? Number(req.query.limit) : undefined;
   const season =
     req.query.season !== undefined
       ? isNaN(req.query.season)
@@ -209,18 +217,32 @@ router.get('/stats/leaders', async (req, res, next) => {
         : Number(req.query.season)
       : undefined;
 
-  const result = await statLeaders({ group, leaderCategories, limit, season });
+  if (group === undefined) {
+    const err = new Error(
+      "Required query param 'group' missing. Available groups: hitting, pitching."
+    );
+    err.status = 400;
+    next(err);
+  }
+
+  if (season === undefined) {
+    const err = new Error(
+      'Required query param `season` missing. Available seasons: a 0-indexed Blaseball season or `current`.'
+    );
+    err.status = 400;
+    next(err);
+  }
+
+  const result = await statLeaders({ group, season });
 
   res.json(result);
 });
 
 /**
- * Gets available options, limits, and mapped IDs to help navigate the API
+ * Gets available options, limits, and mapped IDs to help navigate the API.
  *
- * @route GET /config
- * @group Meta
+ * @route GET /v2/config
  * @group APIv2
- * @summary Get object with properties useful for navigating API
  * @returns {[object]} 200
  */
 router.get('/config', async (req, res, next) => {

--- a/lib/routes/v2.js
+++ b/lib/routes/v2.js
@@ -1,6 +1,7 @@
 const Router = require('express-promise-router');
 
-const { playerStats } = require('../controllers/stats.js');
+const { config } = require('../controllers/config.js');
+const { playerStats, statLeaders } = require('../controllers/stats.js');
 const { player, players } = require('../controllers/players.js');
 const { team, teams } = require('../controllers/teams.js');
 
@@ -130,9 +131,13 @@ router.get('/stats', async (req, res, next) => {
   const limit =
     req.query.limit !== undefined ? Number(req.query.limit) : undefined;
   const season =
-    req.query.season !== undefined && isNaN(req.query.season)
-      ? req.query.season
-      : Number(req.query.season);
+    req.query.season !== undefined
+      ? isNaN(req.query.season)
+        ? req.query.season
+        : Number(req.query.season)
+      : undefined;
+  const fields =
+    req.query.fields !== undefined ? req.query.fields.split(',') : undefined;
 
   if (group === undefined) {
     const err = new Error(
@@ -151,6 +156,7 @@ router.get('/stats', async (req, res, next) => {
   }
 
   const result = await playerStats({
+    fields,
     gameType,
     group,
     limit,
@@ -161,6 +167,50 @@ router.get('/stats', async (req, res, next) => {
     teamId,
     type,
   });
+
+  res.json(result);
+});
+
+/**
+ * Get stats for players and teams.
+ *
+ * @route GET /stats/leaders
+ * @group Stat Leaders
+ * @group APIv2
+ * @summary Get a list of stat leader splits
+ * @returns {[object]} 200 - list of stat leader splits
+ */
+router.get('/stats/leaders', async (req, res, next) => {
+  const { group } = req.query;
+  const leaderCategories =
+    req.query.leaderCategories !== undefined
+      ? req.query.leaderCategories.split(',')
+      : undefined;
+  const limit =
+    req.query.limit !== undefined ? Number(req.query.limit) : undefined;
+  const season =
+    req.query.season !== undefined
+      ? isNaN(req.query.season)
+        ? req.query.season
+        : Number(req.query.season)
+      : undefined;
+
+  const result = await statLeaders({ group, leaderCategories, limit, season });
+
+  res.json(result);
+});
+
+/**
+ * Gets available options, limits, and mapped IDs to help navigate the API
+ *
+ * @route GET /config
+ * @group Meta
+ * @group APIv2
+ * @summary Get object with properties useful for navigating API
+ * @returns {[object]} 200
+ */
+router.get('/config', async (req, res, next) => {
+  const result = await config();
 
   res.json(result);
 });

--- a/package.json
+++ b/package.json
@@ -1,18 +1,19 @@
 {
   "name": "sibr-api",
-  "version": "1.3.5",
+  "version": "1.5.0",
   "description": "API for SIBR statistics.",
   "main": "lib/index.js",
   "scripts": {
     "build": "babel lib -d dist",
     "dev": "nodemon --exec babel-node lib/index.js",
+    "postinstall": "prisma generate",
     "start": "yarn run build && node dist/index.js"
   },
   "repository": "https://github.com/Society-For-Blaseball-Research/sibr-api",
   "author": "Corvimae",
   "license": "MIT",
   "dependencies": {
-    "@prisma/client": "^2.13.1",
+    "@prisma/client": "^2.16.0",
     "core-js": "^3.6.5",
     "cors": "^2.8.5",
     "dotenv": "^8.2.0",
@@ -27,7 +28,7 @@
     "@babel/core": "^7.12.3",
     "@babel/node": "^7.12.1",
     "@babel/preset-env": "^7.12.1",
-    "@prisma/cli": "^2.13.1",
+    "@prisma/cli": "^2.16.0",
     "husky": ">=4",
     "lint-staged": ">=10",
     "nodemon": "^2.0.5",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -253,29 +253,32 @@ model Player {
   blood            String?
   url_slug         String?
 
-  current_state       String?
-  current_location    String?
-  debut_gameday       Int?
-  debut_season        Int?
-  debut_tournament    Int?
-  gameday_from        Int?
-  season_from         Int?
-  tournament_from     Int?
-  phase_type_from     String?
-  position_id         Int?
-  position_type       String?
-  team                String?
-  team_abbreviation   String?
-  team_id             String?
-  modifications       String[]
-  baserunning_rating  Int?
-  baserunning_stars   Int?
-  batting_rating      Int?
-  batting_stars       Int?
-  defense_rating      Int?
-  defense_stars       Int?
-  pitching_rating     Int?
-  pitching_stars      Int?
+  current_state         String?
+  current_location      String?
+  debut_gameday         Int?
+  debut_season          Int?
+  debut_tournament      Int?
+  incineration_season   Int?
+  incineration_gameday  Int?
+  incineration_phase    String?
+  gameday_from          Int?
+  season_from           Int?
+  tournament_from       Int?
+  phase_type_from       String?
+  position_id           Int?
+  position_type         String?
+  team                  String?
+  team_abbreviation     String?
+  team_id               String?
+  modifications         String[]
+  baserunning_rating    Int?
+  baserunning_stars     Int?
+  batting_rating        Int?
+  batting_stars         Int?
+  defense_rating        Int?
+  defense_stars         Int?
+  pitching_rating       Int?
+  pitching_stars        Int?
 
   @@id(fields: [player_id, valid_from])
   @@map("players_info_expanded_all")
@@ -283,23 +286,27 @@ model Player {
 
 // @View - Must be manually updated with every new Prisma introspection
 model Team {
-  team_id             String
-  location            String
-  nickname            String
-  full_name           String
-  team_abbreviation   String?
-  url_slug            String
-  current_team_status String
-  valid_from          DateTime
-  valid_until         DateTime?
-  gameday_from        Int?
-  season_from         Int?
-  division            String?
-  division_id         String?
-  league              String?
-  league_id           String?
-  tournament_name     String?
-  modifications       String[]
+  team_id               String
+  location              String
+  nickname              String
+  full_name             String
+  team_abbreviation     String?
+  url_slug              String
+  current_team_status   String
+  valid_from            DateTime
+  valid_until           DateTime?
+  gameday_from          Int?
+  season_from           Int?
+  division              String?
+  division_id           String?
+  league                String?
+  league_id             String?
+  tournament_name       String?
+  modifications          String[]
+  team_main_color       String
+  team_secondary_color  String
+  team_slogan           String
+  team_emoji            String
 
   @@id(fields: [team_id, valid_from])
   @@map("teams_info_expanded_all")
@@ -341,16 +348,17 @@ model PlayerBattingStatsSeason {
   home_runs             Int
   runs_batted_in        Int
   strikeouts            Int
-  sacrifices            Int
+  sacrifice_bunts        Int
+  sacrifice_flies         Int
   at_bats_risp          Int
-  hits_risps            Int
+  hits_risp             Int
   batting_average_risp  Float?
   on_base_slugging      Float?
   total_bases           Int
-  hbps                  Int
+  hit_by_pitches        Int
   ground_outs           Int
   flyouts               Int
-  gidps                 Int
+  gidp                  Int
 
   @@id(fields: [player_id, season])
   @@map("batting_stats_player_season")
@@ -373,21 +381,21 @@ model PlayerBattingStatsPostseason {
   singles               Int
   doubles               Int
   triples               Int
-  // @TODO: Add quadruples to player batting stats postseason view
-  // quadruples            Int
+  quadruples            Int
   home_runs             Int
   runs_batted_in        Int
   strikeouts            Int
-  sacrifices            Int
+  sacrifice_bunts        Int
+  sacrifice_flies         Int
   at_bats_risp          Int
-  hits_risps            Int
+  hits_risp             Int
   batting_average_risp  Float?
   on_base_slugging      Float?
   total_bases           Int
-  hbps                  Int
+  hit_by_pitches        Int
   ground_outs           Int
   flyouts               Int
-  gidps                 Int
+  gidp                  Int
 
   @@id(fields: [player_id, season])
   @@map("batting_stats_player_playoffs_season")
@@ -396,33 +404,33 @@ model PlayerBattingStatsPostseason {
 
 // @View - Must be manually updated with every new Prisma introspection
 model PlayerPitchingStatsSeason {
-  player_id       String
-  player_name     String
-  season          Int
-  team_id         String
-  games           Int
-  wins            Int
-  losses          Int
-  win_pct         Float
-  pitch_count     Int
-  batters_faced   Int
-  outs_recorded   Int
-  innings         Int
-  runs_allowed    Int
-  shutouts        Int
-  quality_starts  Int
-  strikeouts      Int
-  walks           Int
-  hrs_allowed     Int
-  hits_allowed    Int
-  hbps            Float
-  era             Float
-  bb_per_9        Float
-  hits_per_9      Float
-  k_per_9         Float
-  hr_per_9        Float
-  whip            Float
-  k_bb            Float
+  player_id             String
+  player_name           String
+  season                Int
+  team_id               String
+  games                 Int
+  wins                  Int
+  losses                Int
+  win_pct               Float
+  pitches_thrown        Int
+  batters_faced         Int
+  outs_recorded         Int
+  innings               Int
+  runs_allowed          Int
+  shutouts              Int
+  quality_starts        Int
+  strikeouts            Int
+  walks                 Int
+  home_runs_allowed     Int
+  hits_allowed          Int
+  hit_by_pitches        Float
+  earned_run_average    Float
+  walks_per_9           Float
+  hits_per_9            Float
+  strikeouts_per_9      Float
+  home_runs_per_9       Float
+  whip                  Float
+  strikeouts_per_walk   Float
 
   @@id(fields: [player_id, season])
   @@map("pitching_stats_player_season")
@@ -430,33 +438,33 @@ model PlayerPitchingStatsSeason {
 
 // @View - Must be manually updated with every new Prisma introspection
 model PlayerPitchingStatsPostseason {
-  player_id       String
-  player_name     String
-  season          Int
-  team_id         String
-  games           Int
-  wins            Int
-  losses          Int
-  win_pct         Float
-  pitch_count     Int
-  batters_faced   Int
-  outs_recorded   Int
-  innings         Int
-  runs_allowed    Int
-  shutouts        Int
-  quality_starts  Int
-  strikeouts      Int
-  walks           Int
-  hrs_allowed     Int
-  hits_allowed    Int
-  hbps            Float
-  era             Float
-  bb_per_9        Float
-  hits_per_9      Float
-  k_per_9         Float
-  hr_per_9        Float
-  whip            Float
-  k_bb            Float
+  player_id             String
+  player_name           String
+  season                Int
+  team_id               String
+  games                 Int
+  wins                  Int
+  losses                Int
+  win_pct               Float
+  pitches_thrown        Int
+  batters_faced         Int
+  outs_recorded         Int
+  innings               Int
+  runs_allowed          Int
+  shutouts              Int
+  quality_starts        Int
+  strikeouts            Int
+  walks                 Int
+  home_runs_allowed     Int
+  hits_allowed          Int
+  hit_by_pitches        Float
+  earned_run_average    Float
+  walks_per_9           Float
+  hits_per_9            Float
+  strikeouts_per_9      Float
+  home_runs_per_9       Float
+  whip                  Float
+  strikeouts_per_walk   Float
 
   @@id(fields: [player_id, season])
   @@map("pitching_stats_player_playoffs_season")

--- a/yarn.lock
+++ b/yarn.lock
@@ -873,35 +873,29 @@
   dependencies:
     chokidar "2.1.8"
 
-"@prisma/bar@^0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@prisma/bar/-/bar-0.0.1.tgz#088c4fbbb79c588391437ade9fd3a85527e753b3"
-  integrity sha512-FVLhwVkbfhXlBhroWfIXMLi+3Jh9IEzYp+9z+MUUiw3ZsbcoAil7CN9/QIjHc4/TcCRyRfuSmT7qCnn4O+TjJw==
-
-"@prisma/cli@^2.13.1":
-  version "2.13.1"
-  resolved "https://registry.yarnpkg.com/@prisma/cli/-/cli-2.13.1.tgz#6af36f3e1a99852c6232202946043263a537cd95"
-  integrity sha512-1KIo29GFAM/oe56oVFB6SjLV+xaunBtcnln1v0KcSn0bx1MgdN00o0haB5qTqRwnqEMTqsS81zH8VwdIgQhn6A==
+"@prisma/cli@^2.16.0":
+  version "2.16.0"
+  resolved "https://registry.yarnpkg.com/@prisma/cli/-/cli-2.16.0.tgz#78bc00ac31495a40de27dc4e7822e748d07aef83"
+  integrity sha512-sgZVHyTN8tC8rneJ17+p8XWoS2bzt1BBADAf2rbvl5sQpVQo7YD4cGZHJS01i+tOlGb05jGAyY5NvuHI5251dw==
   dependencies:
-    "@prisma/bar" "^0.0.1"
-    "@prisma/engines" "2.13.1-2.fcbc4bb2d306c86c28014f596b1e8c7980af8bd4"
+    "@prisma/engines" "2.16.0-43.a973e24a4e5194f8fe3301bfa7ff982b24f97c05"
 
-"@prisma/client@^2.13.1":
-  version "2.13.1"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.13.1.tgz#7379eeca980afc2fe64d2c745eb90480877f30f4"
-  integrity sha512-aD33DJpVHU3VqwDk5PEgnffbQeilUqmwVgqIxstVEiZ7TSs5oXQjwsSWAEfuvzPsR/rMJdeauAov58WHlMbVVA==
+"@prisma/client@^2.16.0":
+  version "2.16.0"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.16.0.tgz#811dcb8310544876b88a0bbd230a2f65c58a9c01"
+  integrity sha512-q02/IKwUIN+9Kl+Oayfb6x38NQ4ROvLoPSE+V0DRlJehTAJoxgRUWuPwaiOkksVnnmK4XHvKS/TR5EmQHUVxYw==
   dependencies:
-    "@prisma/engines-version" "2.13.1-2.fcbc4bb2d306c86c28014f596b1e8c7980af8bd4"
+    "@prisma/engines-version" "2.16.0-44.854c8ba7f0dce66f115af36af24e66989a8c02a1"
 
-"@prisma/engines-version@2.13.1-2.fcbc4bb2d306c86c28014f596b1e8c7980af8bd4":
-  version "2.13.1-2.fcbc4bb2d306c86c28014f596b1e8c7980af8bd4"
-  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-2.13.1-2.fcbc4bb2d306c86c28014f596b1e8c7980af8bd4.tgz#9f5d48054aeeea0dfffeb45572aba7097e33c198"
-  integrity sha512-xMfD9iu03XSTgZqgWYqTnKYfmabjY+U2tj7ClA1WQqLziY0ZGI48tZQpNe6WGzv+6nVss3PpfHfkKlM0kzhZbw==
+"@prisma/engines-version@2.16.0-44.854c8ba7f0dce66f115af36af24e66989a8c02a1":
+  version "2.16.0-44.854c8ba7f0dce66f115af36af24e66989a8c02a1"
+  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-2.16.0-44.854c8ba7f0dce66f115af36af24e66989a8c02a1.tgz#6df1a9a9f4c711e18861be2de4c4f0e363d0aae9"
+  integrity sha512-/gcqWJDXoo0vsYi7fhdhdyjfMXxJPjKl8K7oc/k2BH7IQuXUB1A+ZnFgqRcT/rKuyU4xH8+N+l+C4boWlqYvgQ==
 
-"@prisma/engines@2.13.1-2.fcbc4bb2d306c86c28014f596b1e8c7980af8bd4":
-  version "2.13.1-2.fcbc4bb2d306c86c28014f596b1e8c7980af8bd4"
-  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-2.13.1-2.fcbc4bb2d306c86c28014f596b1e8c7980af8bd4.tgz#4a6aba46db9be442712e4b14b5a72e1da830e837"
-  integrity sha512-APwZRomHG94bOc3jY6kaoEOkVdavN859c5hCFOjhy014Uut8v5+dg1lz3RzUaiiSHK8NwgGKrO5rqO09yGu8Eg==
+"@prisma/engines@2.16.0-43.a973e24a4e5194f8fe3301bfa7ff982b24f97c05":
+  version "2.16.0-43.a973e24a4e5194f8fe3301bfa7ff982b24f97c05"
+  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-2.16.0-43.a973e24a4e5194f8fe3301bfa7ff982b24f97c05.tgz#f3cbfe5aed6ec437fe30c5b6a503e925cf86088a"
+  integrity sha512-vwZhfa/w+2mzoKMquCogpegLKuZnu/RmhVMDUYxuSSw8o+tjanYpuvJYImioDZ+FoU1vTawxqMc4kfD1yKYRlA==
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"


### PR DESCRIPTION
The v2 stat leaders endpoint has been added with support for season-based stat category leaders obtained via the `ref_leaderboard_season_pitching` and `ref_leaderboard_season_batting` database functions. The endpoint does not include limit or field filtering at the moment. Replacing the database functions with API functions should help with supporting those types of calls in the future.

This pull request also introduces a new endpoint, `/v2/config`, to provide useful information for API consumers. For instance, a consumer can use the information found in this endpoint to obtain stat category information, available stat seasons, and suggested defaults to use with other endpoints.

And for the Datablase server, the Prisma Client binary will now be generated after every `yarn install` run. This should happen with each new version push to DockerHub. See the Prisma documentation for [Deploying the Prisma Client](https://www.prisma.io/docs/concepts/components/prisma-client/deployment) and [Prisma Client Overview](https://www.prisma.io/docs/concepts/components/prisma-client).