### PR TITLE
Add v2 endpoint for team stats

### DIFF
--- a/lib/controllers/stats.js
+++ b/lib/controllers/stats.js
@@ -1,6 +1,9 @@
 import { getCurrentSeason } from '../controllers/timeMap.js';
 import prisma from '../prisma.js';
 
+// A list of base running fields for `fields` stat filters and to fill in nulls when a relation doesn't exist
+const BASE_RUNNING_FIELDS = ['stolen_bases', 'caught_stealing', 'runs'];
+
 // @TODO: Add stat leader limit, leaderCategories filters
 // @TODO: Replace ref_leaderboard database functions
 // @TODO: Add all-time and single season leaders
@@ -18,6 +21,7 @@ export async function statLeaders({ group, season, type = 'season' } = {}) {
     let leaders;
     let view;
 
+    // Select the appropriate function or view based on request
     if (type === 'season') {
       if (statGroup === 'hitting') {
         leaders = await prisma.$queryRaw`SELECT * FROM ref_leaderboard_season_batting(${season})`;
@@ -82,7 +86,107 @@ export async function statLeaders({ group, season, type = 'season' } = {}) {
   return response;
 }
 
-// @TODO: Add explicit types for career, single season, single game, etc
+// @TODO: Add postseason stats
+export async function teamStats({
+  fields,
+  gameType = 'R',
+  group,
+  limit,
+  order = 'desc',
+  season,
+  sortStat,
+  teamId,
+  type = 'season',
+}) {
+  if (type === 'season' && season === 'current') {
+    season = await getCurrentSeason();
+  }
+
+  const statGroups = group.split(',');
+
+  let response = [];
+
+  for (const statGroup of statGroups) {
+    let statGroupResult = {};
+    let view;
+
+    if (type === 'season') {
+      if (statGroup === 'hitting' && gameType === 'R') {
+        view = prisma.teamBattingStatsSeason;
+      } else if (statGroup === 'pitching' && gameType === 'R') {
+        view = prisma.teamPitchingStatsSeason;
+      } else {
+        throw new Error(
+          `Unsupported value provided for 'group' parameter: ${statGroup}`
+        );
+      }
+    } else {
+      throw new Error(
+        `Unsupported value provided for 'type' parameter: ${type}`
+      );
+    }
+
+    const viewResults = await queryPrismaView({
+      fields,
+      limit,
+      order,
+      sortStat,
+      season,
+      statGroup,
+      teamId,
+      type,
+      view,
+    });
+
+    // Attach the stat group information
+    statGroupResult.group = statGroup;
+    statGroupResult.type = type;
+    statGroupResult.totalSplits = viewResults.length;
+    statGroupResult.splits = [];
+
+    // Insert the stat group splits
+    for (const record of viewResults) {
+      const {
+        team,
+        team_id,
+        team_valid_from,
+        team_valid_until,
+        season,
+        ...stat
+      } = record;
+
+      // Merge stat fields from runningStats association object into stat object
+      if (Object.prototype.hasOwnProperty.call(stat, 'runningStats')) {
+        if (stat.runningStats !== null) {
+          // Discard unused non-base running stat fields
+          const { season, team, team_id, ...runningStats } = stat.runningStats;
+
+          stat = { ...stat, ...runningStats };
+        } else {
+          // If a player does not have base running stats for a particular season, fill with 0s
+          BASE_RUNNING_FIELDS.forEach((baseRunningStat) => {
+            stat[baseRunningStat] = 0;
+          });
+        }
+
+        // Remove the association record since the fields were embedded into the `stat` property
+        delete stat.runningStats;
+      }
+
+      statGroupResult.splits.push({
+        season,
+        stat,
+        team: team,
+      });
+    }
+
+    response.push(statGroupResult);
+  }
+
+  return response;
+}
+
+// @TODO: Add explicit types for single season, single game, etc
 export async function playerStats({
   fields,
   gameType = 'R',
@@ -95,9 +199,6 @@ export async function playerStats({
   teamId,
   type = 'season',
 }) {
-  // A list of base running fields for `fields` filters and to fill in nulls when a relation doesn't exist
-  const BASE_RUNNING_FIELDS = ['stolen_bases', 'caught_stealing', 'runs'];
-
   if (type === 'season' && season === 'current') {
     season = await getCurrentSeason();
   }
@@ -144,48 +245,17 @@ export async function playerStats({
       );
     }
 
-    // The requested sort stat along with a default ASC sort on `season`
-    const orderByFilterWithDefaults = [
-      ...(sortStat !== undefined ? [{ [sortStat]: order }] : []),
-      ...(type === 'season'
-        ? [
-            {
-              season: 'asc',
-            },
-          ]
-        : []),
-    ];
-
-    // The relations to include with the request
-    const relationFields =
-      // `include` cannot be used with `select`, so set to undefined when `fields` param is set
-      fields === undefined
-        ? {
-            ...(statGroup === 'hitting' ? { runningStats: true } : {}),
-            ...(type === 'season' ? { team: true } : {}),
-          }
-        : undefined;
-
-    // Build the Prisma query
-    const viewResults = await view.findMany({
-      select: getFieldSelection({
-        baseRunningFields: BASE_RUNNING_FIELDS,
-        fieldSelection: fields,
-        splitType: type,
-      }),
-      include:
-        relationFields !== undefined &&
-        relationFields.constructor === Object &&
-        Object.keys(relationFields).length !== 0
-          ? relationFields
-          : undefined,
-      where: {
-        season,
-        player_id: playerId,
-        team_id: teamId,
-      },
-      take: limit,
-      orderBy: orderByFilterWithDefaults,
+    const viewResults = await queryPrismaView({
+      fields,
+      limit,
+      order,
+      sortStat,
+      playerId,
+      season,
+      statGroup,
+      teamId,
+      type,
+      view,
     });
 
     // Attach the stat group information
@@ -252,7 +322,12 @@ export async function playerStats({
 }
 
 // Build the `select` query to include requested fields as well as relations
-function getFieldSelection({ baseRunningFields, fieldSelection, splitType }) {
+function getFieldSelection({
+  baseRunningFields,
+  isPlayerStatRequest = true,
+  fieldSelection,
+  splitType,
+}) {
   if (
     baseRunningFields === undefined ||
     fieldSelection === undefined ||
@@ -282,13 +357,14 @@ function getFieldSelection({ baseRunningFields, fieldSelection, splitType }) {
     },
     {
       // Always return the following fields in addition to the requested fields
-      player_id: true,
-      player_name: true,
+      ...(isPlayerStatRequest === true ? { player_id: true } : {}),
+      ...(isPlayerStatRequest === true ? { player_name: true } : {}),
       // The `season` column does not exist in non-season views
       ...(splitType === 'season' ? { season: true } : {}),
       // The `team` association does not exist in career views
-      ...(splitType !== 'career'
-        ? {
+      ...(isPlayerStatRequest === true && splitType === 'career'
+        ? {}
+        : {
             team: {
               // Because `select` cannot be used on the same level as `include` in Prisma,
               // we must select each association field (issue could be addressed by Prisma in future)
@@ -316,8 +392,67 @@ function getFieldSelection({ baseRunningFields, fieldSelection, splitType }) {
                 team_emoji: true,
               },
             },
-          }
-        : {}),
+          }),
     }
   );
+}
+
+async function queryPrismaView({
+  fields,
+  limit,
+  order,
+  playerId,
+  season,
+  sortStat,
+  statGroup,
+  teamId,
+  type,
+  view,
+}) {
+  // The requested sort stat along with a default ASC sort on `season`
+  const orderByFilterWithDefaults = [
+    ...(sortStat !== undefined ? [{ [sortStat]: order }] : []),
+    ...(type === 'season'
+      ? [
+          {
+            season: 'asc',
+          },
+        ]
+      : []),
+  ];
+
+  // The relations to include with the request
+  const relationFields =
+    // `include` cannot be used with `select`, so set to undefined when `fields` param is set
+    fields === undefined
+      ? {
+          ...(statGroup === 'hitting' ? { runningStats: true } : {}),
+          ...(type === 'season' ? { team: true } : {}),
+        }
+      : undefined;
+
+  // Build the Prisma query
+  const viewResults = await view.findMany({
+    select: getFieldSelection({
+      baseRunningFields: BASE_RUNNING_FIELDS,
+      fieldSelection: fields,
+      splitType: type,
+    }),
+    include:
+      // Include relationFields' properties if they exist
+      relationFields !== undefined &&
+      relationFields.constructor === Object &&
+      Object.keys(relationFields).length !== 0
+        ? relationFields
+        : undefined,
+    where: {
+      season,
+      ...(playerId != null ? { player_id: playerId } : {}),
+      team_id: teamId,
+    },
+    take: limit,
+    orderBy: orderByFilterWithDefaults,
+  });
+
+  return viewResults;
 }

--- a/lib/controllers/stats.js
+++ b/lib/controllers/stats.js
@@ -113,8 +113,12 @@ export async function teamStats({
     if (type === 'season') {
       if (statGroup === 'hitting' && gameType === 'R') {
         view = prisma.teamBattingStatsSeason;
+      } else if (statGroup === 'hitting' && gameType === 'P') {
+        view = prisma.teamBattingStatsPostseason;
       } else if (statGroup === 'pitching' && gameType === 'R') {
         view = prisma.teamPitchingStatsSeason;
+      } else if (statGroup === 'pitching' && gameType === 'P') {
+        view = prisma.teamPitchingStatsPostseason;
       } else {
         throw new Error(
           `Unsupported value provided for 'group' parameter: ${statGroup}`

--- a/lib/routes/v2.js
+++ b/lib/routes/v2.js
@@ -1,7 +1,11 @@
 const Router = require('express-promise-router');
 
 const { config } = require('../controllers/config.js');
-const { playerStats, statLeaders } = require('../controllers/stats.js');
+const {
+  playerStats,
+  statLeaders,
+  teamStats,
+} = require('../controllers/stats.js');
 const { player, players } = require('../controllers/players.js');
 const { team, teams } = require('../controllers/teams.js');
 
@@ -140,7 +144,7 @@ router.get('/players/:playerIdOrSlug', async (req, res, next) => {
 });
 
 /**
- * Get stats for players and teams.
+ * Get stats for players.
  *
  * @route GET /v2/stats
  * @group Stats
@@ -181,14 +185,6 @@ router.get('/stats', async (req, res, next) => {
   if (group === undefined) {
     const err = new Error(
       "Required query param 'group' missing. Available groups: hitting, pitching."
-    );
-    err.status = 400;
-    return next(err);
-  }
-
-  if (type === undefined) {
-    const err = new Error(
-      'Required query param `type` missing. Available types: season.'
     );
     err.status = 400;
     return next(err);
@@ -238,7 +234,80 @@ router.get('/stats', async (req, res, next) => {
 });
 
 /**
- * Get stats for players and teams.
+ * Get stats for teams.
+ *
+ * @route GET /v2/stats/teams
+ * @group Stats
+ * @group APIv2
+ * @param {string} type.query.required - The type of stat split (defaults to `season`).
+ * @param {string} group.query.required - The stat groups to return (e.g. `hitting,pitching` or `hitting`).
+ * @param {string} fields.query - The stat fields to return (e.g. `strikeouts,home_runs` or `home_runs`).
+ * @param {string} season.query - The (0-indexed) Blaseball season (or `current` for current season).
+ * @param {string} gameType.query - The type of game (e.g. `R` for regular season, `P` for postseason).
+ * @param {string} sortStat.query - The stat field to sort on.
+ * @param {string} order.query - The order of the sorted stat field.
+ * @param {string} teamId.query - The ID of a team to retrieve player stats for.
+ * @param {string} limit.query - The number of rows to return for each field (e.g. `5`).
+ * @returns {[object]} 200 - list of stat splits
+ */
+router.get('/stats/teams', async (req, res, next) => {
+  const {
+    gameType,
+    group,
+    order,
+    playerId,
+    sortStat,
+    teamId,
+    type,
+  } = req.query;
+  const limit =
+    req.query.limit !== undefined ? Number(req.query.limit) : undefined;
+  const season =
+    req.query.season !== undefined
+      ? isNaN(req.query.season)
+        ? req.query.season
+        : Number(req.query.season)
+      : undefined;
+  const fields =
+    req.query.fields !== undefined ? req.query.fields.split(',') : undefined;
+
+  if (group === undefined) {
+    const err = new Error(
+      "Required query param 'group' missing. Available groups: hitting, pitching."
+    );
+    err.status = 400;
+    return next(err);
+  }
+
+  // Return an error when `fiields` is used when more than one `group` is requested
+  // Possible fix: Standardize the fields across groups, or prefix them with their group
+  // so that they can be used in their appropriate group query.
+  if (fields !== undefined && group.split(',').length > 1) {
+    const err = new Error(
+      'Query param `fields` cannot be used with multiple groups at this time.'
+    );
+    err.status = 400;
+    return next(err);
+  }
+
+  const result = await teamStats({
+    fields,
+    gameType,
+    group,
+    limit,
+    order,
+    playerId,
+    season,
+    sortStat,
+    teamId,
+    type,
+  });
+
+  res.json(result);
+});
+
+/**
+ * Get stats for players.
  *
  * @route GET /v2/stats/leaders
  * @group Stat Leaders

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -313,8 +313,10 @@ model Team {
   PlayerPitchingStatsSeason     PlayerPitchingStatsSeason[]
   PlayerPitchingStatsPostseason PlayerPitchingStatsPostseason[]
 
-  TeamBattingStatsSeason  TeamBattingStatsSeason[]
-  TeamPitchingStatsSeason TeamPitchingStatsSeason[]
+  TeamBattingStatsSeason      TeamBattingStatsSeason[]
+  TeamBattingStatsPostseason  TeamBattingStatsPostseason[]
+  TeamPitchingStatsSeason     TeamPitchingStatsSeason[]
+  TeamPitchingStatsPostseason TeamPitchingStatsPostseason[]
 
   @@id(fields: [team_id, valid_from])
   @@map("teams_info_expanded_all")
@@ -536,6 +538,46 @@ model TeamBattingStatsSeason {
   @@map("batting_stats_team_season")
 }
 
+// @View - Must be manually updated with every new Prisma introspection
+model TeamBattingStatsPostseason {
+  team_id              String
+  team_valid_from      DateTime
+  team_valid_until     DateTime?
+  season               Int
+  batting_average      Float?
+  on_base_percentage   Float?
+  slugging             Float?
+  appearances          Int
+  plate_appearances    Int
+  at_bats              Int
+  hits                 Int
+  walks                Int
+  singles              Int
+  doubles              Int
+  triples              Int
+  quadruples           Int
+  home_runs            Int
+  runs_batted_in       Float
+  strikeouts           Int
+  sacrifice_bunts      Int
+  sacrifice_flies      Int
+  at_bats_risp         Int
+  hits_risp            Int
+  batting_average_risp Float?
+  on_base_slugging     Float?
+  total_bases          Int
+  hit_by_pitches       Int
+  ground_outs          Int
+  flyouts              Int
+  gidp                 Int
+
+  runningStats TeamRunningStatsPostseason?
+  team         Team                        @relation(fields: [team_id, team_valid_from], references: [team_id, valid_from])
+
+  @@id(fields: [team_id, season])
+  @@map("batting_stats_team_playoffs_season")
+}
+
 // Pitching Stats
 
 // @View - Must be manually updated with every new Prisma introspection
@@ -714,6 +756,42 @@ model TeamPitchingStatsSeason {
   @@map("pitching_stats_team_season")
 }
 
+// @View - Must be manually updated with every new Prisma introspection
+model TeamPitchingStatsPostseason {
+  season              Int
+  team_id             String
+  team_valid_from     DateTime
+  team_valid_until    DateTime?
+  games               Int
+  wins                Int
+  losses              Int
+  win_pct             Float
+  pitches_thrown      Int
+  batters_faced       Int
+  outs_recorded       Int
+  innings             Float
+  runs_allowed        Float
+  shutouts            Int
+  quality_starts      Int
+  strikeouts          Int
+  walks               Int
+  home_runs_allowed   Int
+  hits_allowed        Int
+  hit_by_pitches      Float
+  earned_run_average  Float
+  walks_per_9         Float
+  hits_per_9          Float
+  strikeouts_per_9    Float
+  home_runs_per_9     Float
+  whip                Float
+  strikeouts_per_walk Float
+
+  team Team @relation(fields: [team_id, team_valid_from], references: [team_id, valid_from])
+
+  @@id(fields: [team_id, season])
+  @@map("pitching_stats_team_playoffs_season")
+}
+
 // Base Running Stats
 
 // @View - Must be manually updated with every new Prisma introspection
@@ -795,6 +873,21 @@ model TeamRunningStatsSeason {
 
   @@id(fields: [team_id, season])
   @@map("running_stats_team_season")
+}
+
+// @View - Must be manually updated with every new Prisma introspection
+model TeamRunningStatsPostseason {
+  team            String?
+  team_id         String
+  season          Int
+  stolen_bases    Int
+  caught_stealing Int
+  runs            Float
+
+  battingStats TeamBattingStatsPostseason @relation(fields: [team_id, season], references: [team_id, season])
+
+  @@id(fields: [team_id, season])
+  @@map("running_stats_team_playoffs_season")
 }
 
 // Leaderboards

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -312,6 +312,10 @@ model Team {
   PlayerBattingStatsPostseason  PlayerBattingStatsPostseason[]
   PlayerPitchingStatsSeason     PlayerPitchingStatsSeason[]
   PlayerPitchingStatsPostseason PlayerPitchingStatsPostseason[]
+
+  TeamBattingStatsSeason  TeamBattingStatsSeason[]
+  TeamPitchingStatsSeason TeamPitchingStatsSeason[]
+
   @@id(fields: [team_id, valid_from])
   @@map("teams_info_expanded_all")
 }
@@ -492,6 +496,46 @@ model PlayerBattingStatsPostseasonLifetime {
   @@map("batting_stats_player_playoffs_lifetime")
 }
 
+// @View - Must be manually updated with every new Prisma introspection
+model TeamBattingStatsSeason {
+  team_id              String
+  team_valid_from      DateTime
+  team_valid_until     DateTime?
+  season               Int
+  batting_average      Float?
+  on_base_percentage   Float?
+  slugging             Float?
+  appearances          Int
+  plate_appearances    Int
+  at_bats              Int
+  hits                 Int
+  walks                Int
+  singles              Int
+  doubles              Int
+  triples              Int
+  quadruples           Int
+  home_runs            Int
+  runs_batted_in       Float
+  strikeouts           Int
+  sacrifice_bunts      Int
+  sacrifice_flies      Int
+  at_bats_risp         Int
+  hits_risp            Int
+  batting_average_risp Float?
+  on_base_slugging     Float?
+  total_bases          Int
+  hit_by_pitches       Int
+  ground_outs          Int
+  flyouts              Int
+  gidp                 Int
+
+  runningStats TeamRunningStatsSeason?
+  team         Team                    @relation(fields: [team_id, team_valid_from], references: [team_id, valid_from])
+
+  @@id(fields: [team_id, season])
+  @@map("batting_stats_team_season")
+}
+
 // Pitching Stats
 
 // @View - Must be manually updated with every new Prisma introspection
@@ -531,8 +575,6 @@ model PlayerPitchingStatsSeason {
   @@id(fields: [player_id, season, team_id])
   @@map("pitching_stats_player_season")
 }
-
-// @TODO: Use Player to set up relations for stats?
 
 // @View - Must be manually updated with every new Prisma introspection
 model PlayerPitchingStatsPostseason {
@@ -636,6 +678,42 @@ model PlayerPitchingStatsPostseasonLifetime {
   @@map("pitching_stats_player_playoffs_lifetime")
 }
 
+// @View - Must be manually updated with every new Prisma introspection
+model TeamPitchingStatsSeason {
+  season              Int
+  team_id             String
+  team_valid_from     DateTime
+  team_valid_until    DateTime?
+  games               Int
+  wins                Int
+  losses              Int
+  win_pct             Float
+  pitches_thrown      Int
+  batters_faced       Int
+  outs_recorded       Int
+  innings             Float
+  runs_allowed        Float
+  shutouts            Int
+  quality_starts      Int
+  strikeouts          Int
+  walks               Int
+  home_runs_allowed   Int
+  hits_allowed        Int
+  hit_by_pitches      Float
+  earned_run_average  Float
+  walks_per_9         Float
+  hits_per_9          Float
+  strikeouts_per_9    Float
+  home_runs_per_9     Float
+  whip                Float
+  strikeouts_per_walk Float
+
+  team Team @relation(fields: [team_id, team_valid_from], references: [team_id, valid_from])
+
+  @@id(fields: [team_id, season])
+  @@map("pitching_stats_team_season")
+}
+
 // Base Running Stats
 
 // @View - Must be manually updated with every new Prisma introspection
@@ -702,6 +780,21 @@ model PlayerRunningStatsPostseasonLifetime {
 
   @@id(fields: [player_id])
   @@map("running_stats_player_playoffs_lifetime")
+}
+
+// @View - Must be manually updated with every new Prisma introspection
+model TeamRunningStatsSeason {
+  team            String?
+  team_id         String
+  season          Int
+  stolen_bases    Int
+  caught_stealing Int
+  runs            Float
+
+  battingStats TeamBattingStatsSeason @relation(fields: [team_id, season], references: [team_id, season])
+
+  @@id(fields: [team_id, season])
+  @@map("running_stats_team_season")
 }
 
 // Leaderboards


### PR DESCRIPTION
Adds a new endpoint at `/v2/stats/teams` with support for regular season team stats. Postseason team stats will be added once those views are available in the database. 