### PR TITLE
Add `/v2/games` endpoints

### DIFF
--- a/Datablase.postman_collection.json
+++ b/Datablase.postman_collection.json
@@ -1,2342 +1,2940 @@
 {
-  "info": {
-    "_postman_id": "12c1a47a-da12-43b4-bd17-a6a69d2fc12d",
-    "name": "Datablase Tests",
-    "description": "Automated testing for the Datablase API",
-    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
-  },
-  "item": [
-    {
-      "name": "v1",
-      "item": [
-        {
-          "name": "Events",
-          "item": [
-            {
-              "name": "Query for game events.",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Conner hits dingers\", function () {\r",
-                      "    var jsonData = pm.response.json();\r",
-                      "    pm.expect(jsonData.count).greaterThan(180);\r",
-                      "    pm.expect(jsonData.results.length).equals(jsonData.count);\r",
-                      "    pm.variables.set(\"conner_dingers\", jsonData.count);\r",
-                      "});\r",
-                      "\r",
-                      ""
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/v1/events?type=HOME_RUN&batterId=740d5fef-d59f-4dac-9a75-739ec07f91cf",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["v1", "events"],
-                  "query": [
-                    {
-                      "key": "playerId",
-                      "value": "<string>",
-                      "description": "The ID of a player that must be the batter or the pitcher in each event.",
-                      "disabled": true
-                    },
-                    {
-                      "key": "gameId",
-                      "value": "<string>",
-                      "description": "The ID of the game by which to filter results.",
-                      "disabled": true
-                    },
-                    {
-                      "key": "pitcherId",
-                      "value": "<string>",
-                      "description": "The ID of the pitcher that must be in each event.",
-                      "disabled": true
-                    },
-                    {
-                      "key": "type",
-                      "value": "HOME_RUN",
-                      "description": "The type of event by which to filter."
-                    },
-                    {
-                      "key": "outcomes",
-                      "value": "<boolean>",
-                      "description": "Include child player event records.",
-                      "disabled": true
-                    },
-                    {
-                      "key": "baseRunners",
-                      "value": "<boolean>",
-                      "description": "Include child base runner records.",
-                      "disabled": true
-                    },
-                    {
-                      "key": "sortBy",
-                      "value": "<string>",
-                      "description": "The field by which to sort. Most text and numeric columns are supported.",
-                      "disabled": true
-                    },
-                    {
-                      "key": "sortDirection",
-                      "value": "<string>",
-                      "description": "The direction by which to sort. Must be one of ASC, DESC.",
-                      "disabled": true
-                    },
-                    {
-                      "key": "batterId",
-                      "value": "740d5fef-d59f-4dac-9a75-739ec07f91cf"
-                    }
-                  ]
-                },
-                "description": "Get the list of game events that match the query. One of `playerId`, `gameId`, `pitcherId`, `batterId` must be specified."
-              },
-              "response": [
-                {
-                  "name": "The events that match the query and the number of matching events.",
-                  "originalRequest": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{baseUrl}}/v1/events?playerId=<string>&gameId=<string>&pitcherId=<string>&batterId=<string>&type=<string>&outcomes=<boolean>&baseRunners=<boolean>&sortBy=<string>&sortDirection=<string>",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["v1", "events"],
-                      "query": [
-                        {
-                          "key": "playerId",
-                          "value": "<string>"
-                        },
-                        {
-                          "key": "gameId",
-                          "value": "<string>"
-                        },
-                        {
-                          "key": "pitcherId",
-                          "value": "<string>"
-                        },
-                        {
-                          "key": "batterId",
-                          "value": "<string>"
-                        },
-                        {
-                          "key": "type",
-                          "value": "<string>"
-                        },
-                        {
-                          "key": "outcomes",
-                          "value": "<boolean>"
-                        },
-                        {
-                          "key": "baseRunners",
-                          "value": "<boolean>"
-                        },
-                        {
-                          "key": "sortBy",
-                          "value": "<string>"
-                        },
-                        {
-                          "key": "sortDirection",
-                          "value": "<string>"
-                        }
-                      ]
-                    }
-                  },
-                  "status": "OK",
-                  "code": 200,
-                  "_postman_previewlanguage": "text",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "text/plain"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": ""
-                }
-              ]
-            },
-            {
-              "name": "Calculate the number of events for each batter or pitcher.",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Same number of dingers\", function () {\r",
-                      "    var jsonData = pm.response.json();\r",
-                      "    pm.expect(jsonData.batters[0].count === pm.variables.get(\"conner_dingers\"))\r",
-                      "});\r",
-                      "\r",
-                      "pm.test(\"Over 100 pitchers dinged\", function () {\r",
-                      "    var jsonData = pm.response.json();\r",
-                      "    pm.expect(jsonData.pitchers.length).greaterThan(100);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/v1/countByType?eventType=HOME_RUN&batterId=740d5fef-d59f-4dac-9a75-739ec07f91cf",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["v1", "countByType"],
-                  "query": [
-                    {
-                      "key": "eventType",
-                      "value": "HOME_RUN",
-                      "description": "(Required) The type of event to count."
-                    },
-                    {
-                      "key": "batterId",
-                      "value": "740d5fef-d59f-4dac-9a75-739ec07f91cf",
-                      "description": "The ID of the batter(s) by which to filter."
-                    },
-                    {
-                      "key": "pitcherId",
-                      "value": "<string>",
-                      "description": "The ID of the pitcher(s) by which to filter.",
-                      "disabled": true
-                    }
-                  ]
-                },
-                "description": "Get the number of events for a batter or pitcher with a certain `event_type`."
-              },
-              "response": [
-                {
-                  "name": "The number of events the batter was involved in with the specified type.",
-                  "originalRequest": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{baseUrl}}/v1/countByType?eventType=<string>&batterId=<string>&pitcherId=<string>",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["v1", "countByType"],
-                      "query": [
-                        {
-                          "key": "eventType",
-                          "value": "<string>"
-                        },
-                        {
-                          "key": "batterId",
-                          "value": "<string>"
-                        },
-                        {
-                          "key": "pitcherId",
-                          "value": "<string>"
-                        }
-                      ]
-                    }
-                  },
-                  "status": "OK",
-                  "code": 200,
-                  "_postman_previewlanguage": "text",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "text/plain"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": ""
-                }
-              ]
-            },
-            {
-              "name": "Scorigami",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Over 375 sclorigamis\", function () {",
-                      "    var jsonData = pm.response.json();",
-                      "    console.log(jsonData.length);",
-                      "    pm.expect(jsonData.length).greaterThan(375);",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/v1/sclorigami",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["v1", "sclorigami"]
-                }
-              },
-              "response": []
-            }
-          ]
-        },
-        {
-          "name": "Players",
-          "item": [
-            {
-              "name": "playerInfo",
-              "item": [
-                {
-                  "name": "playerInfo by Player ID",
-                  "event": [
-                    {
-                      "listen": "test",
-                      "script": {
-                        "exec": [""],
-                        "type": "text/javascript"
-                      }
-                    }
-                  ],
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{baseUrl}}/v1/playerInfo?playerId=740d5fef-d59f-4dac-9a75-739ec07f91cf&all=true",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["v1", "playerInfo"],
-                      "query": [
-                        {
-                          "key": "playerId",
-                          "value": "740d5fef-d59f-4dac-9a75-739ec07f91cf"
-                        },
-                        {
-                          "key": "all",
-                          "value": "true"
-                        },
-                        {
-                          "key": "name",
-                          "value": "<string>",
-                          "description": "The name of the player (takes precedence if slug is specified)",
-                          "disabled": true
-                        },
-                        {
-                          "key": "slug",
-                          "value": "<string>",
-                          "description": "The url_slug of the player",
-                          "disabled": true
-                        }
-                      ]
-                    },
-                    "description": "Get extended player info for a given player, given a player id, name, or slug."
-                  },
-                  "response": [
-                    {
-                      "name": "array of objects",
-                      "originalRequest": {
-                        "method": "GET",
-                        "header": [],
-                        "url": {
-                          "raw": "{{baseUrl}}/v1/playerInfo?playerId=<string>&name=<string>&slug=<string>&all=<boolean>",
-                          "host": ["{{baseUrl}}"],
-                          "path": ["v1", "playerInfo"],
-                          "query": [
-                            {
-                              "key": "playerId",
-                              "value": "<string>"
-                            },
-                            {
-                              "key": "name",
-                              "value": "<string>"
-                            },
-                            {
-                              "key": "slug",
-                              "value": "<string>"
-                            },
-                            {
-                              "key": "all",
-                              "value": "<boolean>"
-                            }
-                          ]
-                        }
-                      },
-                      "status": "OK",
-                      "code": 200,
-                      "_postman_previewlanguage": "text",
-                      "header": [
-                        {
-                          "key": "Content-Type",
-                          "value": "text/plain"
-                        }
-                      ],
-                      "cookie": [],
-                      "body": ""
-                    }
-                  ]
-                },
-                {
-                  "name": "playerInfo by Name",
-                  "event": [
-                    {
-                      "listen": "test",
-                      "script": {
-                        "exec": [""],
-                        "type": "text/javascript"
-                      }
-                    }
-                  ],
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{baseUrl}}/v1/playerInfo?name=Conner Haley&all=true",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["v1", "playerInfo"],
-                      "query": [
-                        {
-                          "key": "playerId",
-                          "value": "<string>",
-                          "description": "The player ID of the player (takes precedence if other params are specified)",
-                          "disabled": true
-                        },
-                        {
-                          "key": "name",
-                          "value": "Conner Haley",
-                          "description": "The name of the player (takes precedence if slug is specified)"
-                        },
-                        {
-                          "key": "slug",
-                          "value": "<string>",
-                          "description": "The url_slug of the player",
-                          "disabled": true
-                        },
-                        {
-                          "key": "all",
-                          "value": "true",
-                          "description": "(default:false) If true, all historical info for the player will be returned, rather than just the current info"
-                        }
-                      ]
-                    },
-                    "description": "Get extended player info for a given player, given a player id, name, or slug."
-                  },
-                  "response": [
-                    {
-                      "name": "array of objects",
-                      "originalRequest": {
-                        "method": "GET",
-                        "header": [],
-                        "url": {
-                          "raw": "{{baseUrl}}/v1/playerInfo?playerId=<string>&name=<string>&slug=<string>&all=<boolean>",
-                          "host": ["{{baseUrl}}"],
-                          "path": ["v1", "playerInfo"],
-                          "query": [
-                            {
-                              "key": "playerId",
-                              "value": "<string>"
-                            },
-                            {
-                              "key": "name",
-                              "value": "<string>"
-                            },
-                            {
-                              "key": "slug",
-                              "value": "<string>"
-                            },
-                            {
-                              "key": "all",
-                              "value": "<boolean>"
-                            }
-                          ]
-                        }
-                      },
-                      "status": "OK",
-                      "code": 200,
-                      "_postman_previewlanguage": "text",
-                      "header": [
-                        {
-                          "key": "Content-Type",
-                          "value": "text/plain"
-                        }
-                      ],
-                      "cookie": [],
-                      "body": ""
-                    }
-                  ]
-                },
-                {
-                  "name": "playerInfo by Slug",
-                  "event": [
-                    {
-                      "listen": "test",
-                      "script": {
-                        "exec": [""],
-                        "type": "text/javascript"
-                      }
-                    }
-                  ],
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{baseUrl}}/v1/playerInfo?all=true&slug=conner-haley",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["v1", "playerInfo"],
-                      "query": [
-                        {
-                          "key": "playerId",
-                          "value": "<string>",
-                          "description": "The player ID of the player (takes precedence if other params are specified)",
-                          "disabled": true
-                        },
-                        {
-                          "key": "name",
-                          "value": "<string>",
-                          "description": "The name of the player (takes precedence if slug is specified)",
-                          "disabled": true
-                        },
-                        {
-                          "key": "all",
-                          "value": "true",
-                          "description": "(default:false) If true, all historical info for the player will be returned, rather than just the current info"
-                        },
-                        {
-                          "key": "slug",
-                          "value": "conner-haley"
-                        }
-                      ]
-                    },
-                    "description": "Get extended player info for a given player, given a player id, name, or slug."
-                  },
-                  "response": [
-                    {
-                      "name": "array of objects",
-                      "originalRequest": {
-                        "method": "GET",
-                        "header": [],
-                        "url": {
-                          "raw": "{{baseUrl}}/v1/playerInfo?playerId=<string>&name=<string>&slug=<string>&all=<boolean>",
-                          "host": ["{{baseUrl}}"],
-                          "path": ["v1", "playerInfo"],
-                          "query": [
-                            {
-                              "key": "playerId",
-                              "value": "<string>"
-                            },
-                            {
-                              "key": "name",
-                              "value": "<string>"
-                            },
-                            {
-                              "key": "slug",
-                              "value": "<string>"
-                            },
-                            {
-                              "key": "all",
-                              "value": "<boolean>"
-                            }
-                          ]
-                        }
-                      },
-                      "status": "OK",
-                      "code": 200,
-                      "_postman_previewlanguage": "text",
-                      "header": [
-                        {
-                          "key": "Content-Type",
-                          "value": "text/plain"
-                        }
-                      ],
-                      "cookie": [],
-                      "body": ""
-                    }
-                  ]
-                }
-              ],
-              "event": [
-                {
-                  "listen": "prerequest",
-                  "script": {
-                    "type": "text/javascript",
-                    "exec": [""]
-                  }
-                },
-                {
-                  "listen": "test",
-                  "script": {
-                    "type": "text/javascript",
-                    "exec": [
-                      "pm.test(\"More than 1 result\", function () {",
-                      "    var jsonData = pm.response.json();",
-                      "    pm.expect(jsonData.length).greaterThan(1);",
-                      "});",
-                      ""
-                    ]
-                  }
-                }
-              ]
-            },
-            {
-              "name": "playerIdsByName",
-              "item": [
-                {
-                  "name": "playerIdsByName: Wyatt Mason",
-                  "event": [
-                    {
-                      "listen": "test",
-                      "script": {
-                        "exec": [
-                          "pm.test(\"More than 10 results\", function () {\r",
-                          "    var jsonData = pm.response.json();\r",
-                          "    pm.expect(jsonData.length).greaterThan(10);\r",
-                          "});"
-                        ],
-                        "type": "text/javascript"
-                      }
-                    }
-                  ],
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{baseUrl}}/v1/playerIdsByName?name=Wyatt Mason&current=false",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["v1", "playerIdsByName"],
-                      "query": [
-                        {
-                          "key": "name",
-                          "value": "Wyatt Mason",
-                          "description": "The name of the player"
-                        },
-                        {
-                          "key": "current",
-                          "value": "false",
-                          "description": "If true, only players currently using this name will be returned"
-                        }
-                      ]
-                    },
-                    "description": "Get all player IDs matching a given name"
-                  },
-                  "response": [
-                    {
-                      "name": "Wyatt Mason",
-                      "originalRequest": {
-                        "method": "GET",
-                        "header": [],
-                        "url": {
-                          "raw": "{{baseUrl}}/v1/playerIdsByName?name=Wyatt Mason&current=false",
-                          "host": ["{{baseUrl}}"],
-                          "path": ["v1", "playerIdsByName"],
-                          "query": [
-                            {
-                              "key": "name",
-                              "value": "Wyatt Mason",
-                              "description": "The name of the player"
-                            },
-                            {
-                              "key": "current",
-                              "value": "false",
-                              "description": "If true, only players currently using this name will be returned"
-                            }
-                          ]
-                        }
-                      },
-                      "status": "OK",
-                      "code": 200,
-                      "_postman_previewlanguage": "json",
-                      "header": [
-                        {
-                          "key": "Server",
-                          "value": "nginx/1.19.1"
-                        },
-                        {
-                          "key": "Date",
-                          "value": "Sat, 28 Nov 2020 03:56:02 GMT"
-                        },
-                        {
-                          "key": "Content-Type",
-                          "value": "application/json; charset=utf-8"
-                        },
-                        {
-                          "key": "Content-Length",
-                          "value": "2431"
-                        },
-                        {
-                          "key": "Connection",
-                          "value": "keep-alive"
-                        },
-                        {
-                          "key": "X-Powered-By",
-                          "value": "Express"
-                        },
-                        {
-                          "key": "Access-Control-Allow-Origin",
-                          "value": "*"
-                        },
-                        {
-                          "key": "ETag",
-                          "value": "W/\"97f-LVEvqdJXFDbfuURjGB1yAmWRUkY\""
-                        }
-                      ],
-                      "cookie": [],
-                      "body": "[\n    {\n        \"player_id\": \"0bb35615-63f2-4492-80ec-b6b322dc5450\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:25:43.399Z\"\n    },\n    {\n        \"player_id\": \"0d5300f6-0966-430f-903f-a4c2338abf00\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:55:48.749Z\"\n    },\n    {\n        \"player_id\": \"1f159bab-923a-4811-b6fa-02bfde50925a\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:25:43.399Z\"\n    },\n    {\n        \"player_id\": \"21d52455-6c2c-4ee4-8673-ab46b4b926b4\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:25:43.399Z\"\n    },\n    {\n        \"player_id\": \"27c68d7f-5e40-4afa-8b6f-9df47b79e7dd\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:25:43.399Z\"\n    },\n    {\n        \"player_id\": \"5ca7e854-dc00-4955-9235-d7fcd732ddcf\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:25:43.399Z\"\n    },\n    {\n        \"player_id\": \"63df8701-1871-4987-87d7-b55d4f1df2e9\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T22:10:51.203Z\"\n    },\n    {\n        \"player_id\": \"75f9d874-5e69-438d-900d-a3fcb1d429b3\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:10:40.842Z\"\n    },\n    {\n        \"player_id\": \"80e474a3-7d2b-431d-8192-2f1e27162607\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-12T20:25:34.306Z\",\n        \"valid_until\": \"2020-08-12T20:40:36.879Z\"\n    },\n    {\n        \"player_id\": \"a1ed3396-114a-40bc-9ff0-54d7e1ad1718\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T20:55:38.256Z\"\n    },\n    {\n        \"player_id\": \"bf6a24d1-4e89-4790-a4ba-eeb2870cbf6f\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:40:45.977Z\"\n    },\n    {\n        \"player_id\": \"e16c3f28-eecd-4571-be1a-606bbac36b2b\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T20:55:38.256Z\"\n    },\n    {\n        \"player_id\": \"e4034192-4dc6-4901-bb30-07fe3cf77b5e\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:25:43.399Z\"\n    },\n    {\n        \"player_id\": \"ea44bd36-65b4-4f3b-ac71-78d87a540b48\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:40:45.977Z\"\n    },\n    {\n        \"player_id\": \"f741dc01-2bae-4459-bfc0-f97536193eea\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:25:43.399Z\"\n    }\n]"
-                    }
-                  ]
-                },
-                {
-                  "name": "playerIdsByName: Valid Player",
-                  "event": [
-                    {
-                      "listen": "test",
-                      "script": {
-                        "exec": [
-                          "pm.test(\"Single result\", function () {\r",
-                          "    var jsonData = pm.response.json();\r",
-                          "    pm.expect(jsonData.length).to.eql(1);\r",
-                          "});"
-                        ],
-                        "type": "text/javascript"
-                      }
-                    }
-                  ],
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{baseUrl}}/v1/playerIdsByName?name=Conner Haley&current=true",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["v1", "playerIdsByName"],
-                      "query": [
-                        {
-                          "key": "name",
-                          "value": "Conner Haley",
-                          "description": "The name of the player"
-                        },
-                        {
-                          "key": "current",
-                          "value": "true",
-                          "description": "If true, only players currently using this name will be returned"
-                        }
-                      ]
-                    },
-                    "description": "Get all player IDs matching a given name"
-                  },
-                  "response": [
-                    {
-                      "name": "Wyatt Mason",
-                      "originalRequest": {
-                        "method": "GET",
-                        "header": [],
-                        "url": {
-                          "raw": "{{baseUrl}}/v1/playerIdsByName?name=Wyatt Mason&current=false",
-                          "host": ["{{baseUrl}}"],
-                          "path": ["v1", "playerIdsByName"],
-                          "query": [
-                            {
-                              "key": "name",
-                              "value": "Wyatt Mason",
-                              "description": "The name of the player"
-                            },
-                            {
-                              "key": "current",
-                              "value": "false",
-                              "description": "If true, only players currently using this name will be returned"
-                            }
-                          ]
-                        }
-                      },
-                      "status": "OK",
-                      "code": 200,
-                      "_postman_previewlanguage": "json",
-                      "header": [
-                        {
-                          "key": "Server",
-                          "value": "nginx/1.19.1"
-                        },
-                        {
-                          "key": "Date",
-                          "value": "Sat, 28 Nov 2020 03:56:02 GMT"
-                        },
-                        {
-                          "key": "Content-Type",
-                          "value": "application/json; charset=utf-8"
-                        },
-                        {
-                          "key": "Content-Length",
-                          "value": "2431"
-                        },
-                        {
-                          "key": "Connection",
-                          "value": "keep-alive"
-                        },
-                        {
-                          "key": "X-Powered-By",
-                          "value": "Express"
-                        },
-                        {
-                          "key": "Access-Control-Allow-Origin",
-                          "value": "*"
-                        },
-                        {
-                          "key": "ETag",
-                          "value": "W/\"97f-LVEvqdJXFDbfuURjGB1yAmWRUkY\""
-                        }
-                      ],
-                      "cookie": [],
-                      "body": "[\n    {\n        \"player_id\": \"0bb35615-63f2-4492-80ec-b6b322dc5450\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:25:43.399Z\"\n    },\n    {\n        \"player_id\": \"0d5300f6-0966-430f-903f-a4c2338abf00\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:55:48.749Z\"\n    },\n    {\n        \"player_id\": \"1f159bab-923a-4811-b6fa-02bfde50925a\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:25:43.399Z\"\n    },\n    {\n        \"player_id\": \"21d52455-6c2c-4ee4-8673-ab46b4b926b4\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:25:43.399Z\"\n    },\n    {\n        \"player_id\": \"27c68d7f-5e40-4afa-8b6f-9df47b79e7dd\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:25:43.399Z\"\n    },\n    {\n        \"player_id\": \"5ca7e854-dc00-4955-9235-d7fcd732ddcf\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:25:43.399Z\"\n    },\n    {\n        \"player_id\": \"63df8701-1871-4987-87d7-b55d4f1df2e9\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T22:10:51.203Z\"\n    },\n    {\n        \"player_id\": \"75f9d874-5e69-438d-900d-a3fcb1d429b3\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:10:40.842Z\"\n    },\n    {\n        \"player_id\": \"80e474a3-7d2b-431d-8192-2f1e27162607\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-12T20:25:34.306Z\",\n        \"valid_until\": \"2020-08-12T20:40:36.879Z\"\n    },\n    {\n        \"player_id\": \"a1ed3396-114a-40bc-9ff0-54d7e1ad1718\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T20:55:38.256Z\"\n    },\n    {\n        \"player_id\": \"bf6a24d1-4e89-4790-a4ba-eeb2870cbf6f\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:40:45.977Z\"\n    },\n    {\n        \"player_id\": \"e16c3f28-eecd-4571-be1a-606bbac36b2b\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T20:55:38.256Z\"\n    },\n    {\n        \"player_id\": \"e4034192-4dc6-4901-bb30-07fe3cf77b5e\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:25:43.399Z\"\n    },\n    {\n        \"player_id\": \"ea44bd36-65b4-4f3b-ac71-78d87a540b48\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:40:45.977Z\"\n    },\n    {\n        \"player_id\": \"f741dc01-2bae-4459-bfc0-f97536193eea\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:25:43.399Z\"\n    }\n]"
-                    }
-                  ]
-                },
-                {
-                  "name": "playerIdsByName: Invalid Player",
-                  "event": [
-                    {
-                      "listen": "test",
-                      "script": {
-                        "exec": [
-                          "pm.test(\"Expected no results\", function () {\r",
-                          "    var jsonData = pm.response.json();\r",
-                          "    pm.expect(jsonData.length).to.eql(0);\r",
-                          "});"
-                        ],
-                        "type": "text/javascript"
-                      }
-                    }
-                  ],
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{baseUrl}}/v1/playerIdsByName?name=Fakey McFakeName&current=true",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["v1", "playerIdsByName"],
-                      "query": [
-                        {
-                          "key": "name",
-                          "value": "Fakey McFakeName",
-                          "description": "The name of the player"
-                        },
-                        {
-                          "key": "current",
-                          "value": "true",
-                          "description": "If true, only players currently using this name will be returned"
-                        }
-                      ]
-                    },
-                    "description": "Get all player IDs matching a given name"
-                  },
-                  "response": [
-                    {
-                      "name": "Wyatt Mason",
-                      "originalRequest": {
-                        "method": "GET",
-                        "header": [],
-                        "url": {
-                          "raw": "{{baseUrl}}/v1/playerIdsByName?name=Wyatt Mason&current=false",
-                          "host": ["{{baseUrl}}"],
-                          "path": ["v1", "playerIdsByName"],
-                          "query": [
-                            {
-                              "key": "name",
-                              "value": "Wyatt Mason",
-                              "description": "The name of the player"
-                            },
-                            {
-                              "key": "current",
-                              "value": "false",
-                              "description": "If true, only players currently using this name will be returned"
-                            }
-                          ]
-                        }
-                      },
-                      "status": "OK",
-                      "code": 200,
-                      "_postman_previewlanguage": "json",
-                      "header": [
-                        {
-                          "key": "Server",
-                          "value": "nginx/1.19.1"
-                        },
-                        {
-                          "key": "Date",
-                          "value": "Sat, 28 Nov 2020 03:56:02 GMT"
-                        },
-                        {
-                          "key": "Content-Type",
-                          "value": "application/json; charset=utf-8"
-                        },
-                        {
-                          "key": "Content-Length",
-                          "value": "2431"
-                        },
-                        {
-                          "key": "Connection",
-                          "value": "keep-alive"
-                        },
-                        {
-                          "key": "X-Powered-By",
-                          "value": "Express"
-                        },
-                        {
-                          "key": "Access-Control-Allow-Origin",
-                          "value": "*"
-                        },
-                        {
-                          "key": "ETag",
-                          "value": "W/\"97f-LVEvqdJXFDbfuURjGB1yAmWRUkY\""
-                        }
-                      ],
-                      "cookie": [],
-                      "body": "[\n    {\n        \"player_id\": \"0bb35615-63f2-4492-80ec-b6b322dc5450\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:25:43.399Z\"\n    },\n    {\n        \"player_id\": \"0d5300f6-0966-430f-903f-a4c2338abf00\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:55:48.749Z\"\n    },\n    {\n        \"player_id\": \"1f159bab-923a-4811-b6fa-02bfde50925a\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:25:43.399Z\"\n    },\n    {\n        \"player_id\": \"21d52455-6c2c-4ee4-8673-ab46b4b926b4\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:25:43.399Z\"\n    },\n    {\n        \"player_id\": \"27c68d7f-5e40-4afa-8b6f-9df47b79e7dd\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:25:43.399Z\"\n    },\n    {\n        \"player_id\": \"5ca7e854-dc00-4955-9235-d7fcd732ddcf\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:25:43.399Z\"\n    },\n    {\n        \"player_id\": \"63df8701-1871-4987-87d7-b55d4f1df2e9\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T22:10:51.203Z\"\n    },\n    {\n        \"player_id\": \"75f9d874-5e69-438d-900d-a3fcb1d429b3\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:10:40.842Z\"\n    },\n    {\n        \"player_id\": \"80e474a3-7d2b-431d-8192-2f1e27162607\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-12T20:25:34.306Z\",\n        \"valid_until\": \"2020-08-12T20:40:36.879Z\"\n    },\n    {\n        \"player_id\": \"a1ed3396-114a-40bc-9ff0-54d7e1ad1718\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T20:55:38.256Z\"\n    },\n    {\n        \"player_id\": \"bf6a24d1-4e89-4790-a4ba-eeb2870cbf6f\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:40:45.977Z\"\n    },\n    {\n        \"player_id\": \"e16c3f28-eecd-4571-be1a-606bbac36b2b\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T20:55:38.256Z\"\n    },\n    {\n        \"player_id\": \"e4034192-4dc6-4901-bb30-07fe3cf77b5e\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:25:43.399Z\"\n    },\n    {\n        \"player_id\": \"ea44bd36-65b4-4f3b-ac71-78d87a540b48\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:40:45.977Z\"\n    },\n    {\n        \"player_id\": \"f741dc01-2bae-4459-bfc0-f97536193eea\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:25:43.399Z\"\n    }\n]"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "name": "deceased",
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/v1/deceased",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["v1", "deceased"]
-                },
-                "description": "Get all currently decieased players"
-              },
-              "response": [
-                {
-                  "name": "Array of player objects",
-                  "originalRequest": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{baseUrl}}/v1/deceased",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["v1", "deceased"]
-                    }
-                  },
-                  "status": "OK",
-                  "code": 200,
-                  "_postman_previewlanguage": "text",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "text/plain"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": ""
-                }
-              ]
-            },
-            {
-              "name": "taggedPlayers",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"More than 5 tagged players\", function () {\r",
-                      "    var jsonData = pm.response.json();\r",
-                      "    pm.expect(jsonData.length).greaterThan(5);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/v1/taggedPlayers",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["v1", "taggedPlayers"]
-                },
-                "description": "Get the list of all players currently tagged with some kind of modification (like SHELLED)"
-              },
-              "response": [
-                {
-                  "name": "array of player information including current team id/nickname",
-                  "originalRequest": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{baseUrl}}/v1/taggedPlayers",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["v1", "taggedPlayers"]
-                    }
-                  },
-                  "status": "OK",
-                  "code": 200,
-                  "_postman_previewlanguage": "text",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "text/plain"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": ""
-                }
-              ]
-            },
-            {
-              "name": "allPlayers (no shadows)",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "\r",
-                      "pm.test(\"Greater than 200 players\", function () {\r",
-                      "    var jsonData = pm.response.json();\r",
-                      "    pm.expect(jsonData.length).greaterThan(200);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/v1/allPlayers?includeShadows=false",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["v1", "allPlayers"],
-                  "query": [
-                    {
-                      "key": "includeShadows",
-                      "value": "false",
-                      "description": "whether to include players in the Shadows"
-                    }
-                  ]
-                },
-                "description": "Get the current list of all known players"
-              },
-              "response": [
-                {
-                  "name": "list of players",
-                  "originalRequest": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{baseUrl}}/v1/allPlayers?includeShadows=<boolean>",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["v1", "allPlayers"],
-                      "query": [
-                        {
-                          "key": "includeShadows",
-                          "value": "<boolean>"
-                        }
-                      ]
-                    }
-                  },
-                  "status": "OK",
-                  "code": 200,
-                  "_postman_previewlanguage": "text",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "text/plain"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": ""
-                }
-              ]
-            },
-            {
-              "name": "allPlayersForGameday S10D10",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Should get >300 players for S10D10\", function () {\r",
-                      "    var jsonData = pm.response.json();\r",
-                      "    pm.expect(jsonData.length).greaterThan(300);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/v1/allPlayersForGameday?season=10&day=10",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["v1", "allPlayersForGameday"],
-                  "query": [
-                    {
-                      "key": "season",
-                      "value": "10",
-                      "description": "Season to query (zero-indexed)"
-                    },
-                    {
-                      "key": "day",
-                      "value": "10",
-                      "description": "Day to query (zero-indexed)"
-                    }
-                  ]
-                },
-                "description": "Get the list of all players and their data as of a specific Season and Gameday"
-              },
-              "response": [
-                {
-                  "name": "array of player information including current team id/nickname",
-                  "originalRequest": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{baseUrl}}/v1/allPlayersForGameday?season=<number>&day=<number>",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["v1", "allPlayersForGameday"],
-                      "query": [
-                        {
-                          "key": "season",
-                          "value": "<number>"
-                        },
-                        {
-                          "key": "day",
-                          "value": "<number>"
-                        }
-                      ]
-                    }
-                  },
-                  "status": "OK",
-                  "code": 200,
-                  "_postman_previewlanguage": "text",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "text/plain"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": ""
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Statistics",
-          "item": [
-            {
-              "name": "Get the season leaders for a given category and stat",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Your test name\", function () {\r",
-                      "    var jsonData = pm.response.json();\r",
-                      "    pm.expect(jsonData.length).to.eql(10);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/v1/seasonLeaders?season=9&category=batting&stat=home_runs&order=DESC&limit=10",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["v1", "seasonLeaders"],
-                  "query": [
-                    {
-                      "key": "season",
-                      "value": "9",
-                      "description": "Season to query (zero-indexed)"
-                    },
-                    {
-                      "key": "category",
-                      "value": "batting",
-                      "description": "Stat category (batting, pitching, running, or fielding)"
-                    },
-                    {
-                      "key": "stat",
-                      "value": "home_runs",
-                      "description": "Stat to get the leaders for (as returned from /playerStats)"
-                    },
-                    {
-                      "key": "order",
-                      "value": "DESC",
-                      "description": "Ordering to use for ranking (ASC or DESC)"
-                    },
-                    {
-                      "key": "limit",
-                      "value": "10",
-                      "description": "Number of leaders to return"
-                    }
-                  ]
-                },
-                "description": "Get the season leaders for a given category and stat"
-              },
-              "response": [
-                {
-                  "name": "list of leaders",
-                  "originalRequest": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{baseUrl}}/v1/seasonLeaders?season=<number>&category=<string>&stat=<string>&order=<string>&limit=<number>",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["v1", "seasonLeaders"],
-                      "query": [
-                        {
-                          "key": "season",
-                          "value": "<number>"
-                        },
-                        {
-                          "key": "category",
-                          "value": "<string>"
-                        },
-                        {
-                          "key": "stat",
-                          "value": "<string>"
-                        },
-                        {
-                          "key": "order",
-                          "value": "<string>"
-                        },
-                        {
-                          "key": "limit",
-                          "value": "<number>"
-                        }
-                      ]
-                    }
-                  },
-                  "status": "OK",
-                  "code": 200,
-                  "_postman_previewlanguage": "text",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "text/plain"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": ""
-                }
-              ]
-            },
-            {
-              "name": "Get categorical statistics for the given players",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Exactly 1 result\", function () {\r",
-                      "    var jsonData = pm.response.json();\r",
-                      "    pm.expect(jsonData.length).to.eql(1);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/v1/playerStats?category=batting&season=9&playerIds=740d5fef-d59f-4dac-9a75-739ec07f91cf",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["v1", "playerStats"],
-                  "query": [
-                    {
-                      "key": "category",
-                      "value": "batting",
-                      "description": "either 'batting' or 'pitching'"
-                    },
-                    {
-                      "key": "season",
-                      "value": "9",
-                      "description": "(optional) season to get stats for"
-                    },
-                    {
-                      "key": "playerIds",
-                      "value": "740d5fef-d59f-4dac-9a75-739ec07f91cf",
-                      "description": "comma-separated list of player IDs"
-                    }
-                  ]
-                },
-                "description": "Get performance statistics for a given list of players"
-              },
-              "response": [
-                {
-                  "name": "list of player statistics",
-                  "originalRequest": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{baseUrl}}/v1/playerStats?category=<string>&season=<number>&playerIds=<string>",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["v1", "playerStats"],
-                      "query": [
-                        {
-                          "key": "category",
-                          "value": "<string>"
-                        },
-                        {
-                          "key": "season",
-                          "value": "<number>"
-                        },
-                        {
-                          "key": "playerIds",
-                          "value": "<string>"
-                        }
-                      ]
-                    }
-                  },
-                  "status": "OK",
-                  "code": 200,
-                  "_postman_previewlanguage": "text",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "text/plain"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": ""
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Teams",
-          "item": [
-            {
-              "name": "currentRoster",
-              "item": [
-                {
-                  "name": "currentRoster by teamId",
-                  "event": [
-                    {
-                      "listen": "test",
-                      "script": {
-                        "exec": [""],
-                        "type": "text/javascript"
-                      }
-                    }
-                  ],
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{baseUrl}}/v1/currentRoster?teamId=b024e975-1c4a-4575-8936-a3754a08806a",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["v1", "currentRoster"],
-                      "query": [
-                        {
-                          "key": "teamId",
-                          "value": "b024e975-1c4a-4575-8936-a3754a08806a",
-                          "description": "The ID of the team (takes precedence if slug is given)"
-                        },
-                        {
-                          "key": "slug",
-                          "value": "<string>",
-                          "description": "The slug of the team",
-                          "disabled": true
-                        }
-                      ]
-                    },
-                    "description": "Get the current roster for a given team, using either ID or slug."
-                  },
-                  "response": [
-                    {
-                      "name": "array of roster information",
-                      "originalRequest": {
-                        "method": "GET",
-                        "header": [],
-                        "url": {
-                          "raw": "{{baseUrl}}/v1/currentRoster?teamId=<string>&slug=<string>",
-                          "host": ["{{baseUrl}}"],
-                          "path": ["v1", "currentRoster"],
-                          "query": [
-                            {
-                              "key": "teamId",
-                              "value": "<string>"
-                            },
-                            {
-                              "key": "slug",
-                              "value": "<string>"
-                            }
-                          ]
-                        }
-                      },
-                      "status": "OK",
-                      "code": 200,
-                      "_postman_previewlanguage": "text",
-                      "header": [
-                        {
-                          "key": "Content-Type",
-                          "value": "text/plain"
-                        }
-                      ],
-                      "cookie": [],
-                      "body": ""
-                    }
-                  ]
-                },
-                {
-                  "name": "currentRoster by slug",
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{baseUrl}}/v1/currentRoster?slug=steaks",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["v1", "currentRoster"],
-                      "query": [
-                        {
-                          "key": "teamId",
-                          "value": "<string>",
-                          "description": "The ID of the team (takes precedence if slug is given)",
-                          "disabled": true
-                        },
-                        {
-                          "key": "slug",
-                          "value": "steaks",
-                          "description": "The slug of the team"
-                        }
-                      ]
-                    },
-                    "description": "Get the current roster for a given team, using either ID or slug."
-                  },
-                  "response": [
-                    {
-                      "name": "array of roster information",
-                      "originalRequest": {
-                        "method": "GET",
-                        "header": [],
-                        "url": {
-                          "raw": "{{baseUrl}}/v1/currentRoster?teamId=<string>&slug=<string>",
-                          "host": ["{{baseUrl}}"],
-                          "path": ["v1", "currentRoster"],
-                          "query": [
-                            {
-                              "key": "teamId",
-                              "value": "<string>"
-                            },
-                            {
-                              "key": "slug",
-                              "value": "<string>"
-                            }
-                          ]
-                        }
-                      },
-                      "status": "OK",
-                      "code": 200,
-                      "_postman_previewlanguage": "text",
-                      "header": [
-                        {
-                          "key": "Content-Type",
-                          "value": "text/plain"
-                        }
-                      ],
-                      "cookie": [],
-                      "body": ""
-                    }
-                  ]
-                }
-              ],
-              "event": [
-                {
-                  "listen": "prerequest",
-                  "script": {
-                    "type": "text/javascript",
-                    "exec": [""]
-                  }
-                },
-                {
-                  "listen": "test",
-                  "script": {
-                    "type": "text/javascript",
-                    "exec": [
-                      "pm.test(\"More than one player\", function () {",
-                      "    var jsonData = pm.response.json();",
-                      "    pm.expect(jsonData.length).greaterThan(1);",
-                      "});"
-                    ]
-                  }
-                }
-              ]
-            },
-            {
-              "name": "allTeams",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "\r",
-                      "pm.test(\"More than 36 teams\", function () {\r",
-                      "    var jsonData = pm.response.json();\r",
-                      "    pm.expect(jsonData.length).greaterThan(36);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/v1/allTeams",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["v1", "allTeams"]
-                },
-                "description": "Get all current teams"
-              },
-              "response": [
-                {
-                  "name": "list of current teams",
-                  "originalRequest": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{baseUrl}}/v1/allTeams",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["v1", "allTeams"]
-                    }
-                  },
-                  "status": "OK",
-                  "code": 200,
-                  "_postman_previewlanguage": "text",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "text/plain"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": ""
-                }
-              ]
-            },
-            {
-              "name": "allTeamStars",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "\r",
-                      "pm.test(\"More than 36 teams\", function () {\r",
-                      "    var jsonData = pm.response.json();\r",
-                      "    pm.expect(jsonData.length).greaterThan(36);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/v1/allTeamStars",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["v1", "allTeamStars"]
-                },
-                "description": "Get current star values for all teams"
-              },
-              "response": [
-                {
-                  "name": "list of current team stars",
-                  "originalRequest": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{baseUrl}}/v1/allTeamStars",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["v1", "allTeamStars"]
-                    }
-                  },
-                  "status": "OK",
-                  "code": 200,
-                  "_postman_previewlanguage": "text",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "text/plain"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": ""
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "v2",
-      "item": [
-        {
-          "name": "Teams",
-          "item": [
-            {
-              "name": "/teams",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"should respond with 20 teams for season 7\", function () {",
-                      "    var jsonData = pm.response.json();",
-                      "    pm.expect(jsonData.length).to.equal(20);",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                },
-                {
-                  "listen": "prerequest",
-                  "script": {
-                    "exec": [
-                      "pm.collectionVariables.set(\"season\", \"7\");",
-                      ""
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/v2/teams?season={{season}}",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["v2", "teams"],
-                  "query": [
-                    {
-                      "key": "season",
-                      "value": "{{season}}",
-                      "description": "The (0-indexed) Blaseball season (or `current` for current season)"
-                    }
-                  ]
-                }
-              },
-              "response": [
-                {
-                  "name": "Numbered Season Teams",
-                  "originalRequest": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{baseUrl}}/v2/teams?season=7",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["v2", "teams"],
-                      "query": [
-                        {
-                          "key": "season",
-                          "value": "7",
-                          "description": "The (0-indexed) Blaseball season (or `current` for current season)"
-                        }
-                      ]
-                    }
-                  },
-                  "status": "Not Found",
-                  "code": 404,
-                  "_postman_previewlanguage": "html",
-                  "header": [
-                    {
-                      "key": "X-Powered-By",
-                      "value": "Express"
-                    },
-                    {
-                      "key": "Access-Control-Allow-Origin",
-                      "value": "*"
-                    },
-                    {
-                      "key": "Content-Security-Policy",
-                      "value": "default-src 'none'"
-                    },
-                    {
-                      "key": "X-Content-Type-Options",
-                      "value": "nosniff"
-                    },
-                    {
-                      "key": "Content-Type",
-                      "value": "text/html; charset=utf-8"
-                    },
-                    {
-                      "key": "Content-Length",
-                      "value": "150"
-                    },
-                    {
-                      "key": "Date",
-                      "value": "Sat, 20 Feb 2021 18:32:44 GMT"
-                    },
-                    {
-                      "key": "Connection",
-                      "value": "keep-alive"
-                    },
-                    {
-                      "key": "Keep-Alive",
-                      "value": "timeout=5"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": "<!DOCTYPE html>\n<html lang=\"en\">\n    <head>\n        <meta charset=\"utf-8\">\n        <title>Error</title>\n    </head>\n    <body>\n        <pre>Cannot GET /v1/v2/teams</pre>\n    </body>\n</html>"
-                },
-                {
-                  "name": "Current Season Teams",
-                  "originalRequest": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{baseUrl}}/v2/teams?season=current",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["v2", "teams"],
-                      "query": [
-                        {
-                          "key": "season",
-                          "value": "current",
-                          "description": "The (0-indexed) Blaseball season (or `current` for current season)"
-                        }
-                      ]
-                    }
-                  },
-                  "status": "OK",
-                  "code": 200,
-                  "_postman_previewlanguage": "json",
-                  "header": [
-                    {
-                      "key": "X-Powered-By",
-                      "value": "Express"
-                    },
-                    {
-                      "key": "Access-Control-Allow-Origin",
-                      "value": "*"
-                    },
-                    {
-                      "key": "Content-Type",
-                      "value": "application/json; charset=utf-8"
-                    },
-                    {
-                      "key": "Content-Length",
-                      "value": "13019"
-                    },
-                    {
-                      "key": "ETag",
-                      "value": "W/\"32db-3HelBESZuv/pvWlTIlGOxnPbQl4\""
-                    },
-                    {
-                      "key": "Date",
-                      "value": "Sat, 20 Feb 2021 19:01:41 GMT"
-                    },
-                    {
-                      "key": "Connection",
-                      "value": "keep-alive"
-                    },
-                    {
-                      "key": "Keep-Alive",
-                      "value": "timeout=5"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": "[\n    {\n        \"team_id\": \"105bc3ff-1320-4e37-8ef0-8d595cb95dd0\",\n        \"location\": \"Seattle\",\n        \"nickname\": \"Garages\",\n        \"full_name\": \"Seattle Garages\",\n        \"team_abbreviation\": \"SEA\",\n        \"url_slug\": \"garages\",\n        \"team_current_status\": \"active\",\n        \"valid_from\": \"2020-09-20T19:15:35.880Z\",\n        \"valid_until\": \"2020-09-27T01:24:03.154Z\",\n        \"gameday_from\": null,\n        \"season_from\": 6,\n        \"division\": \"Mild High\",\n        \"division_id\": \"456089f0-f338-4620-a014-9540868789c9\",\n        \"league\": \"Mild\",\n        \"league_id\": \"4fe65afa-804f-4bb2-9b15-1281b2eab110\",\n        \"tournament_name\": null,\n        \"modifications\": [\n            \"BLOOD_DONOR\",\n            \"SHAME_PIT\"\n        ],\n        \"team_main_color\": \"#2b4075\",\n        \"team_secondary_color\": \"#5a83ea\",\n        \"team_slogan\": \"Smells like Team Spirit.\",\n        \"team_emoji\": \"0x1F3B8\"\n    },\n    {\n        \"team_id\": \"23e4cbc1-e9cd-47fa-a35b-bfa06f726cb7\",\n        \"location\": \"Philly\",\n        \"nickname\": \"Pies\",\n        \"full_name\": \"Philly Pies\",\n        \"team_abbreviation\": \"PIES\",\n        \"url_slug\": \"pies\",\n        \"team_current_status\": \"active\",\n        \"valid_from\": \"2020-09-06T19:00:36.117Z\",\n        \"valid_until\": \"2020-09-27T19:00:06.043Z\",\n        \"gameday_from\": null,\n        \"season_from\": 4,\n        \"division\": \"Mild Low\",\n        \"division_id\": \"fadc9684-45b3-47a6-b647-3be3f0735a84\",\n        \"league\": \"Mild\",\n        \"league_id\": \"4fe65afa-804f-4bb2-9b15-1281b2eab110\",\n        \"tournament_name\": null,\n        \"modifications\": [\n            \"BLOOD_THIEF\"\n        ],\n        \"team_main_color\": \"#399d8f\",\n        \"team_secondary_color\": \"#58c3b4\",\n        \"team_slogan\": \"Pie or Die.\",\n        \"team_emoji\": \"0x1F967\"\n    },\n    {\n        \"team_id\": \"36569151-a2fb-43c1-9df7-2df512424c82\",\n        \"location\": \"New York\",\n        \"nickname\": \"Millennials\",\n        \"full_name\": \"New York Millennials\",\n        \"team_abbreviation\": \"NYM\",\n        \"url_slug\": \"millennials\",\n        \"team_current_status\": \"active\",\n        \"valid_from\": \"2020-09-20T19:15:35.880Z\",\n        \"valid_until\": \"2020-09-27T01:24:03.154Z\",\n        \"gameday_from\": null,\n        \"season_from\": 6,\n        \"division\": \"Wild High\",\n        \"division_id\": \"d4cc18de-a136-4271-84f1-32516be91a80\",\n        \"league\": \"Wild\",\n        \"league_id\": \"aabc11a1-81af-4036-9f18-229c759ca8a9\",\n        \"tournament_name\": null,\n        \"modifications\": [\n            \"BLOOD_PITY\",\n            \"SHAME_PIT\"\n        ],\n        \"team_main_color\": \"#ffd4d8\",\n        \"team_secondary_color\": \"#ffd4d8\",\n        \"team_slogan\": \"Youth Will Save Us\",\n        \"team_emoji\": \"0x1F4F1\"\n    },\n    {\n        \"team_id\": \"3f8bbb15-61c0-4e3f-8e4a-907a5fb1565e\",\n        \"location\": \"Boston\",\n        \"nickname\": \"Flowers\",\n        \"full_name\": \"Boston Flowers\",\n        \"team_abbreviation\": \"BOS\",\n        \"url_slug\": \"flowers\",\n        \"team_current_status\": \"active\",\n        \"valid_from\": \"2020-09-20T19:15:35.880Z\",\n        \"valid_until\": \"2020-09-27T01:24:03.154Z\",\n        \"gameday_from\": null,\n        \"season_from\": 6,\n        \"division\": \"Wild Low\",\n        \"division_id\": \"98c92da4-0ea7-43be-bd75-c6150e184326\",\n        \"league\": \"Wild\",\n        \"league_id\": \"aabc11a1-81af-4036-9f18-229c759ca8a9\",\n        \"tournament_name\": null,\n        \"modifications\": [\n            \"BLOOD_WINNER\",\n            \"SHAME_PIT\"\n        ],\n        \"team_main_color\": \"#f7d1ff\",\n        \"team_secondary_color\": \"#f7d1ff\",\n        \"team_slogan\": \"Bloom Goes The Dynamite!\",\n        \"team_emoji\": \"0x1F339\"\n    },\n    {\n        \"team_id\": \"57ec08cc-0411-4643-b304-0e80dbc15ac7\",\n        \"location\": \"Mexico City\",\n        \"nickname\": \"Wild Wings\",\n        \"full_name\": \"Mexico City Wild Wings\",\n        \"team_abbreviation\": \"CDMX\",\n        \"url_slug\": \"wild-wings\",\n        \"team_current_status\": \"active\",\n        \"valid_from\": \"2020-09-19T19:43:08.648Z\",\n        \"valid_until\": \"2020-10-11T19:00:07.710Z\",\n        \"gameday_from\": 105,\n        \"season_from\": 6,\n        \"division\": \"Mild Low\",\n        \"division_id\": \"fadc9684-45b3-47a6-b647-3be3f0735a84\",\n        \"league\": \"Mild\",\n        \"league_id\": \"4fe65afa-804f-4bb2-9b15-1281b2eab110\",\n        \"tournament_name\": null,\n        \"modifications\": [\n            \"BLOOD_THIEF\"\n        ],\n        \"team_main_color\": \"#d15700\",\n        \"team_secondary_color\": \"#ee6300\",\n        \"team_slogan\": \"Wings. Beer. Blaseball.\",\n        \"team_emoji\": \"0x1F357\"\n    },\n    {\n        \"team_id\": \"747b8e4a-7e50-4638-a973-ea7950a3e739\",\n        \"location\": \"Hades\",\n        \"nickname\": \"Tigers\",\n        \"full_name\": \"Hades Tigers\",\n        \"team_abbreviation\": \"TGRS\",\n        \"url_slug\": \"tigers\",\n        \"team_current_status\": \"active\",\n        \"valid_from\": \"2020-09-20T19:15:35.880Z\",\n        \"valid_until\": \"2020-09-27T01:24:03.154Z\",\n        \"gameday_from\": null,\n        \"season_from\": 6,\n        \"division\": \"Mild High\",\n        \"division_id\": \"456089f0-f338-4620-a014-9540868789c9\",\n        \"league\": \"Mild\",\n        \"league_id\": \"4fe65afa-804f-4bb2-9b15-1281b2eab110\",\n        \"tournament_name\": null,\n        \"modifications\": [\n            \"BLOOD_DONOR\",\n            \"SHAME_PIT\"\n        ],\n        \"team_main_color\": \"#5c1c1c\",\n        \"team_secondary_color\": \"#e83622\",\n        \"team_slogan\": \"Never Look Back.\",\n        \"team_emoji\": \"0x1F405\"\n    },\n    {\n        \"team_id\": \"7966eb04-efcc-499b-8f03-d13916330531\",\n        \"location\": \"Yellowstone\",\n        \"nickname\": \"Magic\",\n        \"full_name\": \"Yellowstone Magic\",\n        \"team_abbreviation\": \"YELL\",\n        \"url_slug\": \"magic\",\n        \"team_current_status\": \"active\",\n        \"valid_from\": \"2020-09-06T19:00:36.117Z\",\n        \"valid_until\": \"2020-10-11T19:00:07.710Z\",\n        \"gameday_from\": null,\n        \"season_from\": 4,\n        \"division\": \"Mild Low\",\n        \"division_id\": \"fadc9684-45b3-47a6-b647-3be3f0735a84\",\n        \"league\": \"Mild\",\n        \"league_id\": \"4fe65afa-804f-4bb2-9b15-1281b2eab110\",\n        \"tournament_name\": null,\n        \"modifications\": [\n            \"BLOOD_THIEF\"\n        ],\n        \"team_main_color\": \"#bf0043\",\n        \"team_secondary_color\": \"#f60f63\",\n        \"team_slogan\": \"As Above, So Below\",\n        \"team_emoji\": \"0x2728\"\n    },\n    {\n        \"team_id\": \"878c1bf6-0d21-4659-bfee-916c8314d69c\",\n        \"location\": \"Unlimited\",\n        \"nickname\": \"Tacos\",\n        \"full_name\": \"Unlimited Tacos\",\n        \"team_abbreviation\": \"TACO\",\n        \"url_slug\": \"tacos\",\n        \"team_current_status\": \"active\",\n        \"valid_from\": \"2020-09-20T19:15:35.880Z\",\n        \"valid_until\": \"2020-09-27T01:24:03.154Z\",\n        \"gameday_from\": null,\n        \"season_from\": 6,\n        \"division\": \"Wild Low\",\n        \"division_id\": \"98c92da4-0ea7-43be-bd75-c6150e184326\",\n        \"league\": \"Wild\",\n        \"league_id\": \"aabc11a1-81af-4036-9f18-229c759ca8a9\",\n        \"tournament_name\": null,\n        \"modifications\": [\n            \"BLOOD_WINNER\",\n            \"SHAME_PIT\"\n        ],\n        \"team_main_color\": \"#64376e\",\n        \"team_secondary_color\": \"#b063c1\",\n        \"team_slogan\": \"72° and Infinite\",\n        \"team_emoji\": \"0x1F32E\"\n    },\n    {\n        \"team_id\": \"8d87c468-699a-47a8-b40d-cfb73a5660ad\",\n        \"location\": \"Baltimore\",\n        \"nickname\": \"Crabs\",\n        \"full_name\": \"Baltimore Crabs\",\n        \"team_abbreviation\": \"CRAB\",\n        \"url_slug\": \"crabs\",\n        \"team_current_status\": \"ascended\",\n        \"valid_from\": \"2020-09-20T19:15:35.880Z\",\n        \"valid_until\": \"2020-09-27T01:24:03.154Z\",\n        \"gameday_from\": null,\n        \"season_from\": 6,\n        \"division\": \"Wild High\",\n        \"division_id\": \"d4cc18de-a136-4271-84f1-32516be91a80\",\n        \"league\": \"Wild\",\n        \"league_id\": \"aabc11a1-81af-4036-9f18-229c759ca8a9\",\n        \"tournament_name\": null,\n        \"modifications\": [\n            \"BLOOD_PITY\",\n            \"SHAME_PIT\"\n        ],\n        \"team_main_color\": \"#593037\",\n        \"team_secondary_color\": \"#b05c6b\",\n        \"team_slogan\": \"Claws Up!\",\n        \"team_emoji\": \"0x1F980\"\n    },\n    {\n        \"team_id\": \"979aee4a-6d80-4863-bf1c-ee1a78e06024\",\n        \"location\": \"Hawaii\",\n        \"nickname\": \"Fridays\",\n        \"full_name\": \"Hawaii Fridays\",\n        \"team_abbreviation\": \"FRI\",\n        \"url_slug\": \"fridays\",\n        \"team_current_status\": \"active\",\n        \"valid_from\": \"2020-09-12T23:23:48.074Z\",\n        \"valid_until\": \"2020-10-08T17:44:21.421Z\",\n        \"gameday_from\": 109,\n        \"season_from\": 5,\n        \"division\": \"Mild Low\",\n        \"division_id\": \"fadc9684-45b3-47a6-b647-3be3f0735a84\",\n        \"league\": \"Mild\",\n        \"league_id\": \"4fe65afa-804f-4bb2-9b15-1281b2eab110\",\n        \"tournament_name\": null,\n        \"modifications\": [\n            \"BLOOD_THIEF\"\n        ],\n        \"team_main_color\": \"#3ee652\",\n        \"team_secondary_color\": \"#3ee652\",\n        \"team_slogan\": \"It's Island Time!\",\n        \"team_emoji\": \"0x1F3DD\"\n    },\n    {\n        \"team_id\": \"9debc64f-74b7-4ae1-a4d6-fce0144b6ea5\",\n        \"location\": \"Houston\",\n        \"nickname\": \"Spies\",\n        \"full_name\": \"Houston Spies\",\n        \"team_abbreviation\": \"SPY\",\n        \"url_slug\": \"spies\",\n        \"team_current_status\": \"active\",\n        \"valid_from\": \"2020-09-20T19:15:35.880Z\",\n        \"valid_until\": \"2020-09-27T01:24:03.154Z\",\n        \"gameday_from\": null,\n        \"season_from\": 6,\n        \"division\": \"Wild Low\",\n        \"division_id\": \"98c92da4-0ea7-43be-bd75-c6150e184326\",\n        \"league\": \"Wild\",\n        \"league_id\": \"aabc11a1-81af-4036-9f18-229c759ca8a9\",\n        \"tournament_name\": null,\n        \"modifications\": [\n            \"BLOOD_WINNER\",\n            \"SHAME_PIT\"\n        ],\n        \"team_main_color\": \"#67556b\",\n        \"team_secondary_color\": \"#9e82a4\",\n        \"team_slogan\": \"Bang BANG\",\n        \"team_emoji\": \"0x1F575\"\n    },\n    {\n        \"team_id\": \"a37f9158-7f82-46bc-908c-c9e2dda7c33b\",\n        \"location\": \"Breckenridge\",\n        \"nickname\": \"Jazz Hands\",\n        \"full_name\": \"Breckenridge Jazz Hands\",\n        \"team_abbreviation\": \"JAZZ\",\n        \"url_slug\": \"jazz-hands\",\n        \"team_current_status\": \"active\",\n        \"valid_from\": \"2020-09-20T19:15:35.880Z\",\n        \"valid_until\": \"2020-09-27T01:24:03.154Z\",\n        \"gameday_from\": null,\n        \"season_from\": 6,\n        \"division\": \"Wild High\",\n        \"division_id\": \"d4cc18de-a136-4271-84f1-32516be91a80\",\n        \"league\": \"Wild\",\n        \"league_id\": \"aabc11a1-81af-4036-9f18-229c759ca8a9\",\n        \"tournament_name\": null,\n        \"modifications\": [\n            \"BLOOD_PITY\",\n            \"SHAME_PIT\"\n        ],\n        \"team_main_color\": \"#6388ad\",\n        \"team_secondary_color\": \"#7ba9d7\",\n        \"team_slogan\": \"We’ve Got Winning to Do. Just for You.\",\n        \"team_emoji\": \"0x1F450\"\n    },\n    {\n        \"team_id\": \"adc5b394-8f76-416d-9ce9-813706877b84\",\n        \"location\": \"Kansas City\",\n        \"nickname\": \"Breath Mints\",\n        \"full_name\": \"Kansas City Breath Mints\",\n        \"team_abbreviation\": \"KCBM\",\n        \"url_slug\": \"breath-mints\",\n        \"team_current_status\": \"active\",\n        \"valid_from\": \"2020-09-20T19:15:35.880Z\",\n        \"valid_until\": \"2020-09-27T01:24:03.154Z\",\n        \"gameday_from\": null,\n        \"season_from\": 6,\n        \"division\": \"Mild High\",\n        \"division_id\": \"456089f0-f338-4620-a014-9540868789c9\",\n        \"league\": \"Mild\",\n        \"league_id\": \"4fe65afa-804f-4bb2-9b15-1281b2eab110\",\n        \"tournament_name\": null,\n        \"modifications\": [\n            \"BLOOD_DONOR\",\n            \"SHAME_PIT\"\n        ],\n        \"team_main_color\": \"#178f55\",\n        \"team_secondary_color\": \"#178f55\",\n        \"team_slogan\": \"Fresh Breath, Here We Come.\",\n        \"team_emoji\": \"0x1F36C\"\n    },\n    {\n        \"team_id\": \"b024e975-1c4a-4575-8936-a3754a08806a\",\n        \"location\": \"Dallas\",\n        \"nickname\": \"Steaks\",\n        \"full_name\": \"Dallas Steaks\",\n        \"team_abbreviation\": \"STK\",\n        \"url_slug\": \"steaks\",\n        \"team_current_status\": \"active\",\n        \"valid_from\": \"2020-09-20T19:15:35.880Z\",\n        \"valid_until\": \"2020-09-27T01:24:03.154Z\",\n        \"gameday_from\": null,\n        \"season_from\": 6,\n        \"division\": \"Mild High\",\n        \"division_id\": \"456089f0-f338-4620-a014-9540868789c9\",\n        \"league\": \"Mild\",\n        \"league_id\": \"4fe65afa-804f-4bb2-9b15-1281b2eab110\",\n        \"tournament_name\": null,\n        \"modifications\": [\n            \"BLOOD_DONOR\",\n            \"SHAME_PIT\"\n        ],\n        \"team_main_color\": \"#8c8d8f\",\n        \"team_secondary_color\": \"#b2b3b5\",\n        \"team_slogan\": \"Well Done.\",\n        \"team_emoji\": \"0x1F969\"\n    },\n    {\n        \"team_id\": \"b63be8c2-576a-4d6e-8daf-814f8bcea96f\",\n        \"location\": \"Miami\",\n        \"nickname\": \"Dale\",\n        \"full_name\": \"Miami Dale\",\n        \"team_abbreviation\": \"DALE\",\n        \"url_slug\": \"dale\",\n        \"team_current_status\": \"active\",\n        \"valid_from\": \"2020-09-20T19:15:35.880Z\",\n        \"valid_until\": \"2020-09-27T01:24:03.154Z\",\n        \"gameday_from\": null,\n        \"season_from\": 6,\n        \"division\": \"Wild Low\",\n        \"division_id\": \"98c92da4-0ea7-43be-bd75-c6150e184326\",\n        \"league\": \"Wild\",\n        \"league_id\": \"aabc11a1-81af-4036-9f18-229c759ca8a9\",\n        \"tournament_name\": null,\n        \"modifications\": [\n            \"BLOOD_WINNER\",\n            \"ELECTRIC\",\n            \"LIFE_OF_PARTY\",\n            \"SHAME_PIT\"\n        ],\n        \"team_main_color\": \"#9141ba\",\n        \"team_secondary_color\": \"#cd76fa\",\n        \"team_slogan\": \"¡Dale!\",\n        \"team_emoji\": \"0x1F6A4\"\n    },\n    {\n        \"team_id\": \"b72f3061-f573-40d7-832a-5ad475bd7909\",\n        \"location\": \"San Francisco\",\n        \"nickname\": \"Lovers\",\n        \"full_name\": \"San Francisco Lovers\",\n        \"team_abbreviation\": \"LVRS\",\n        \"url_slug\": \"lovers\",\n        \"team_current_status\": \"active\",\n        \"valid_from\": \"2020-09-20T19:15:35.880Z\",\n        \"valid_until\": \"2020-09-27T01:24:03.154Z\",\n        \"gameday_from\": null,\n        \"season_from\": 6,\n        \"division\": \"Wild High\",\n        \"division_id\": \"d4cc18de-a136-4271-84f1-32516be91a80\",\n        \"league\": \"Wild\",\n        \"league_id\": \"aabc11a1-81af-4036-9f18-229c759ca8a9\",\n        \"tournament_name\": null,\n        \"modifications\": [\n            \"BLOOD_PITY\",\n            \"SHAME_PIT\"\n        ],\n        \"team_main_color\": \"#780018\",\n        \"team_secondary_color\": \"#da0000\",\n        \"team_slogan\": \"Let's Go All The Way!\",\n        \"team_emoji\": \"0x1F48B\"\n    },\n    {\n        \"team_id\": \"bfd38797-8404-4b38-8b82-341da28b1f83\",\n        \"location\": \"Charleston\",\n        \"nickname\": \"Shoe Thieves\",\n        \"full_name\": \"Charleston Shoe Thieves\",\n        \"team_abbreviation\": \"CHST\",\n        \"url_slug\": \"shoe-thieves\",\n        \"team_current_status\": \"active\",\n        \"valid_from\": \"2020-09-06T19:00:36.117Z\",\n        \"valid_until\": \"2020-10-11T19:00:07.710Z\",\n        \"gameday_from\": null,\n        \"season_from\": 4,\n        \"division\": \"Mild Low\",\n        \"division_id\": \"fadc9684-45b3-47a6-b647-3be3f0735a84\",\n        \"league\": \"Mild\",\n        \"league_id\": \"4fe65afa-804f-4bb2-9b15-1281b2eab110\",\n        \"tournament_name\": null,\n        \"modifications\": [\n            \"BLOOD_THIEF\"\n        ],\n        \"team_main_color\": \"#ffce0a\",\n        \"team_secondary_color\": \"#ffce0a\",\n        \"team_slogan\": \"Your Kicks are My Kicks.\",\n        \"team_emoji\": \"0x1F45F\"\n    },\n    {\n        \"team_id\": \"ca3f1c8c-c025-4d8e-8eef-5be6accbeb16\",\n        \"location\": \"Chicago\",\n        \"nickname\": \"Firefighters\",\n        \"full_name\": \"Chicago Firefighters\",\n        \"team_abbreviation\": \"CHI\",\n        \"url_slug\": \"firefighters\",\n        \"team_current_status\": \"active\",\n        \"valid_from\": \"2020-09-20T19:15:35.880Z\",\n        \"valid_until\": \"2020-09-27T01:24:03.154Z\",\n        \"gameday_from\": null,\n        \"season_from\": 6,\n        \"division\": \"Wild High\",\n        \"division_id\": \"d4cc18de-a136-4271-84f1-32516be91a80\",\n        \"league\": \"Wild\",\n        \"league_id\": \"aabc11a1-81af-4036-9f18-229c759ca8a9\",\n        \"tournament_name\": null,\n        \"modifications\": [\n            \"BLOOD_PITY\",\n            \"SHAME_PIT\"\n        ],\n        \"team_main_color\": \"#8c2a3e\",\n        \"team_secondary_color\": \"#d13757\",\n        \"team_slogan\": \"We Are From Chicago\",\n        \"team_emoji\": \"0x1F525\"\n    },\n    {\n        \"team_id\": \"eb67ae5e-c4bf-46ca-bbbc-425cd34182ff\",\n        \"location\": \"Canada\",\n        \"nickname\": \"Moist Talkers\",\n        \"full_name\": \"Canada Moist Talkers\",\n        \"team_abbreviation\": \"CAN\",\n        \"url_slug\": \"moist-talkers\",\n        \"team_current_status\": \"active\",\n        \"valid_from\": \"2020-09-20T19:15:35.880Z\",\n        \"valid_until\": \"2020-09-27T01:24:03.154Z\",\n        \"gameday_from\": null,\n        \"season_from\": 6,\n        \"division\": \"Mild High\",\n        \"division_id\": \"456089f0-f338-4620-a014-9540868789c9\",\n        \"league\": \"Mild\",\n        \"league_id\": \"4fe65afa-804f-4bb2-9b15-1281b2eab110\",\n        \"tournament_name\": null,\n        \"modifications\": [\n            \"BLOOD_DONOR\",\n            \"SHAME_PIT\"\n        ],\n        \"team_main_color\": \"#f5feff\",\n        \"team_secondary_color\": \"#f5feff\",\n        \"team_slogan\": \"SPRAY IT, DON'T SAY IT\",\n        \"team_emoji\": \"0x1F5E3\"\n    },\n    {\n        \"team_id\": \"f02aeae2-5e6a-4098-9842-02d2273f25c7\",\n        \"location\": \"Hellmouth\",\n        \"nickname\": \"Sunbeams\",\n        \"full_name\": \"Hellmouth Sunbeams\",\n        \"team_abbreviation\": \"HELL\",\n        \"url_slug\": \"sunbeams\",\n        \"team_current_status\": \"active\",\n        \"valid_from\": \"2020-09-20T19:15:35.880Z\",\n        \"valid_until\": \"2020-09-27T01:24:03.154Z\",\n        \"gameday_from\": null,\n        \"season_from\": 6,\n        \"division\": \"Wild Low\",\n        \"division_id\": \"98c92da4-0ea7-43be-bd75-c6150e184326\",\n        \"league\": \"Wild\",\n        \"league_id\": \"aabc11a1-81af-4036-9f18-229c759ca8a9\",\n        \"tournament_name\": null,\n        \"modifications\": [\n            \"BLOOD_WINNER\",\n            \"SHAME_PIT\"\n        ],\n        \"team_main_color\": \"#fffbab\",\n        \"team_secondary_color\": \"#fffbab\",\n        \"team_slogan\": \"Stare into the Sun...\",\n        \"team_emoji\": \"0x1F31E\"\n    }\n]"
-                }
-              ]
-            },
-            {
-              "name": "/teams/:teamIdOrSlug",
-              "event": [
-                {
-                  "listen": "prerequest",
-                  "script": {
-                    "exec": [
-                      "pm.variables.set(\"teamIdOrSlug\", \"8d87c468-699a-47a8-b40d-cfb73a5660ad\");",
-                      "pm.variables.set(\"season\", \"7\");"
-                    ],
-                    "type": "text/javascript"
-                  }
-                },
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"should respond with season 7 data for Baltimore Crabs\", function () {",
-                      "    var jsonData = pm.response.json();",
-                      "    pm.expect(jsonData.nickname).to.equal(\"Crabs\");",
-                      "    pm.expect(jsonData.season_from).to.equal(6);",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/v2/teams/{{teamIdOrSlug}}?season={{season}}",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["v2", "teams", "{{teamIdOrSlug}}"],
-                  "query": [
-                    {
-                      "key": "season",
-                      "value": "{{season}}",
-                      "description": "The (0-indexed) Blaseball season (or `current` for current season)"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            }
-          ]
-        },
-        {
-          "name": "Team Stats",
-          "item": [
-            {
-              "name": "/stats/teams?type=season&season=14",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"should respond with 2 stat groups\", function () {",
-                      "    var jsonData = pm.response.json();",
-                      "    pm.expect(jsonData.length).to.equal(2);",
-                      "});",
-                      "",
-                      "pm.test(\"should include 24 splits for hitting group\", function () {",
-                      "    var jsonData = pm.response.json();",
-                      "    var hittingGroup = jsonData.find(function (statGroup) {",
-                      "        return statGroup.group === 'hitting';",
-                      "    });",
-                      "    pm.expect(hittingGroup.totalSplits).to.equal(24);",
-                      "});",
-                      "",
-                      "pm.test(\"should include 24 splits for pitching group\", function () {",
-                      "    var jsonData = pm.response.json();",
-                      "    var pitchingGroup = jsonData.find(function (statGroup) {",
-                      "        return statGroup.group === 'pitching';",
-                      "    });",
-                      "    pm.expect(pitchingGroup.totalSplits).to.equal(24);",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/v2/stats/teams?type=season&gameType=R&group=pitching,hitting&season=14",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["v2", "stats", "teams"],
-                  "query": [
-                    {
-                      "key": "fields",
-                      "value": "triples",
-                      "description": "The stat fields to return (e.g. `strikeouts,home_runs` or `home_runs`)",
-                      "disabled": true
-                    },
-                    {
-                      "key": "sortStat",
-                      "value": "",
-                      "description": "The stat field to sort on",
-                      "disabled": true
-                    },
-                    {
-                      "key": "order",
-                      "value": "",
-                      "description": "The order of the sorted stat field (`asc` or `desc`)",
-                      "disabled": true
-                    },
-                    {
-                      "key": "sortStat",
-                      "value": "",
-                      "description": "The ID of a team to retrieve player stats for",
-                      "disabled": true
-                    },
-                    {
-                      "key": "limit",
-                      "value": "",
-                      "description": "The number of rows to return for each field (e.g. `5`",
-                      "disabled": true
-                    },
-                    {
-                      "key": "type",
-                      "value": "season"
-                    },
-                    {
-                      "key": "gameType",
-                      "value": "R"
-                    },
-                    {
-                      "key": "group",
-                      "value": "pitching,hitting"
-                    },
-                    {
-                      "key": "season",
-                      "value": "14"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            }
-          ]
-        },
-        {
-          "name": "Players",
-          "item": [
-            {
-              "name": "/players",
-              "event": [
-                {
-                  "listen": "prerequest",
-                  "script": {
-                    "exec": ["pm.collectionVariables.set(\"season\", \"7\");"],
-                    "type": "text/javascript"
-                  }
-                },
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"should respond with 20 players for season 7\", function () {",
-                      "    var jsonData = pm.response.json();",
-                      "    pm.expect(jsonData.length).to.equal(573);",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/v2/players?season={{season}}",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["v2", "players"],
-                  "query": [
-                    {
-                      "key": "season",
-                      "value": "{{season}}"
-                    },
-                    {
-                      "key": "playerPool",
-                      "value": "deceased",
-                      "disabled": true
-                    },
-                    {
-                      "key": "sortField",
-                      "value": "anticapitalism",
-                      "disabled": true
-                    },
-                    {
-                      "key": "order",
-                      "value": "desc",
-                      "disabled": true
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "/players/:playerIdOrSlug",
-              "event": [
-                {
-                  "listen": "prerequest",
-                  "script": {
-                    "exec": [
-                      "pm.collectionVariables.set(\"playerIdOrSlug\", \"dominic-marijuana\");"
-                    ],
-                    "type": "text/javascript"
-                  }
-                },
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"should respond with Dominic Marijuana's data\", function () {",
-                      "    var jsonData = pm.response.json();",
-                      "    pm.expect(jsonData.player_id).to.equal(\"7310c32f-8f32-40f2-b086-54555a2c0e86\");",
-                      "    pm.expect(jsonData.debut_season).to.equal(2);",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/v2/players/:playerIdOrSlug",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["v2", "players", ":playerIdOrSlug"],
-                  "variable": [
-                    {
-                      "key": "playerIdOrSlug",
-                      "value": "{{playerIdOrSlug}}",
-                      "description": "A player's ID or URL slug"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            }
-          ]
-        },
-        {
-          "name": "Player Stats",
-          "item": [
-            {
-              "name": "/stats?type=career",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"should respond with 2 stat groups\", function () {",
-                      "    var jsonData = pm.response.json();",
-                      "    pm.expect(jsonData.length).to.equal(2);",
-                      "});",
-                      "",
-                      "pm.test(\"should include at least 286 splits for hitting group\", function () {",
-                      "    var jsonData = pm.response.json();",
-                      "    var hittingGroup = jsonData.find(function (statGroup) {",
-                      "        return statGroup.group === 'hitting';",
-                      "    });",
-                      "    pm.expect(hittingGroup.totalSplits).to.be.gte(286);",
-                      "});",
-                      "",
-                      "pm.test(\"should include at least 139 splits for pitching group\", function () {",
-                      "    var jsonData = pm.response.json();",
-                      "    var pitchingGroup = jsonData.find(function (statGroup) {",
-                      "        return statGroup.group === 'pitching';",
-                      "    });",
-                      "    pm.expect(pitchingGroup.totalSplits).to.be.gte(139);",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/v2/stats?type=career&group=hitting,pitching",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["v2", "stats"],
-                  "query": [
-                    {
-                      "key": "type",
-                      "value": "career",
-                      "description": "The type of stat split (defaults to `season`)"
-                    },
-                    {
-                      "key": "group",
-                      "value": "hitting,pitching",
-                      "description": "The stat groups to return (e.g. `hitting,pitching` or `hitting`)"
-                    },
-                    {
-                      "key": "fields",
-                      "value": "triples",
-                      "description": "The stat fields to return (e.g. `strikeouts,home_runs` or `home_runs`)",
-                      "disabled": true
-                    },
-                    {
-                      "key": "season",
-                      "value": "10",
-                      "description": "The (0-indexed) Blaseball season (or `current` for current season)",
-                      "disabled": true
-                    },
-                    {
-                      "key": "gameType",
-                      "value": "",
-                      "description": "The type of game (e.g. `R` for regular season, `P` for postseason",
-                      "disabled": true
-                    },
-                    {
-                      "key": "sortStat",
-                      "value": "",
-                      "description": "The stat field to sort on",
-                      "disabled": true
-                    },
-                    {
-                      "key": "order",
-                      "value": "",
-                      "description": "The order of the sorted stat field (`asc` or `desc`)",
-                      "disabled": true
-                    },
-                    {
-                      "key": "playerId",
-                      "value": "",
-                      "description": "The ID of a player",
-                      "disabled": true
-                    },
-                    {
-                      "key": "teamId",
-                      "value": "",
-                      "description": "The ID of a team to retrieve player stats for",
-                      "disabled": true
-                    },
-                    {
-                      "key": "limit",
-                      "value": "",
-                      "description": "The number of rows to return for each field (e.g. `5`",
-                      "disabled": true
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "/stats?type=season&season=10",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"should respond with 2 stat groups\", function () {",
-                      "    var jsonData = pm.response.json();",
-                      "    pm.expect(jsonData.length).to.equal(2);",
-                      "});",
-                      "",
-                      "pm.test(\"should include 227 splits for hitting group\", function () {",
-                      "    var jsonData = pm.response.json();",
-                      "    var hittingGroup = jsonData.find(function (statGroup) {",
-                      "        return statGroup.group === 'hitting';",
-                      "    });",
-                      "    pm.expect(hittingGroup.totalSplits).to.equal(227);",
-                      "});",
-                      "",
-                      "pm.test(\"should include 100 splits for pitching group\", function () {",
-                      "    var jsonData = pm.response.json();",
-                      "    var pitchingGroup = jsonData.find(function (statGroup) {",
-                      "        return statGroup.group === 'pitching';",
-                      "    });",
-                      "    pm.expect(pitchingGroup.totalSplits).to.equal(100);",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/v2/stats?type=season&group=hitting,pitching&season=10",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["v2", "stats"],
-                  "query": [
-                    {
-                      "key": "type",
-                      "value": "season",
-                      "description": "The type of stat split (defaults to `season`)"
-                    },
-                    {
-                      "key": "fields",
-                      "value": "triples",
-                      "description": "The stat fields to return (e.g. `strikeouts,home_runs` or `home_runs`)",
-                      "disabled": true
-                    },
-                    {
-                      "key": "gameType",
-                      "value": "",
-                      "description": "The type of game (e.g. `R` for regular season, `P` for postseason",
-                      "disabled": true
-                    },
-                    {
-                      "key": "sortStat",
-                      "value": "",
-                      "description": "The stat field to sort on",
-                      "disabled": true
-                    },
-                    {
-                      "key": "order",
-                      "value": "",
-                      "description": "The order of the sorted stat field (`asc` or `desc`)",
-                      "disabled": true
-                    },
-                    {
-                      "key": "playerId",
-                      "value": "",
-                      "description": "The ID of a player",
-                      "disabled": true
-                    },
-                    {
-                      "key": "teamId",
-                      "value": "",
-                      "description": "The ID of a team to retrieve player stats for",
-                      "disabled": true
-                    },
-                    {
-                      "key": "limit",
-                      "value": "",
-                      "description": "The number of rows to return for each field (e.g. `5`",
-                      "disabled": true
-                    },
-                    {
-                      "key": "group",
-                      "value": "hitting,pitching"
-                    },
-                    {
-                      "key": "season",
-                      "value": "10"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "/stats/leaders",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"should respond with 2 stat groups\", function () {",
-                      "    var jsonData = pm.response.json();",
-                      "    pm.expect(jsonData.length).to.equal(2);",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/v2/stats/leaders?group=hitting,pitching",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["v2", "stats", "leaders"],
-                  "query": [
-                    {
-                      "key": "group",
-                      "value": "hitting,pitching",
-                      "description": "The stat groups to return (e.g. `hitting,pitching` or `hitting`)"
-                    },
-                    {
-                      "key": "season",
-                      "value": null,
-                      "description": "The (0-indexed) Blaseball season (or `current` for current season)",
-                      "disabled": true
-                    },
-                    {
-                      "key": "type",
-                      "value": "",
-                      "description": "The type of leader results to return (e.g. `season` or `career`)",
-                      "disabled": true
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "/stats/leaders&type=career",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"should respond with 2 stat groups\", function () {",
-                      "    var jsonData = pm.response.json();",
-                      "    pm.expect(jsonData.length).to.equal(2);",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/v2/stats/leaders?group=hitting,pitching&type=career",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["v2", "stats", "leaders"],
-                  "query": [
-                    {
-                      "key": "group",
-                      "value": "hitting,pitching",
-                      "description": "The stat groups to return (e.g. `hitting,pitching` or `hitting`)"
-                    },
-                    {
-                      "key": "season",
-                      "value": null,
-                      "description": "The (0-indexed) Blaseball season (or `current` for current season)",
-                      "disabled": true
-                    },
-                    {
-                      "key": "type",
-                      "value": "career",
-                      "description": "The type of leader results to return (e.g. `season` or `career`)"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            }
-          ]
-        }
-      ]
-    }
-  ],
-  "event": [
-    {
-      "listen": "prerequest",
-      "script": {
-        "type": "text/javascript",
-        "exec": [""]
-      }
-    },
-    {
-      "listen": "test",
-      "script": {
-        "type": "text/javascript",
-        "exec": [
-          "pm.test(\"Status code is 200\", function () {",
-          "    pm.response.to.have.status(200);",
-          "});",
-          "",
-          ""
-        ]
-      }
-    }
-  ],
-  "variable": [
-    {
-      "id": "87fb23e8-4cd5-4e9e-9df6-7870068d977e",
-      "key": "baseUrl",
-      "value": "https://api.sibr.dev/datablase"
-    },
-    {
-      "id": "d398360c-6f63-4296-9c53-36aad03b9f97",
-      "key": "season",
-      "value": "7"
-    },
-    {
-      "id": "85a2b506-0653-4a15-8cc0-6d3ebbfd9f03",
-      "key": "playerIdOrSlug",
-      "value": "dominic-marijuana"
-    }
-  ]
+	"info": {
+		"_postman_id": "12c1a47a-da12-43b4-bd17-a6a69d2fc12d",
+		"name": "Datablase Tests",
+		"description": "Automated testing for the Datablase API",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "v1",
+			"item": [
+				{
+					"name": "Events",
+					"item": [
+						{
+							"name": "Query for game events.",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Conner hits dingers\", function () {\r",
+											"    var jsonData = pm.response.json();\r",
+											"    pm.expect(jsonData.count).greaterThan(180);\r",
+											"    pm.expect(jsonData.results.length).equals(jsonData.count);\r",
+											"    pm.variables.set(\"conner_dingers\", jsonData.count);\r",
+											"});\r",
+											"\r",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/v1/events?type=HOME_RUN&batterId=740d5fef-d59f-4dac-9a75-739ec07f91cf",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"v1",
+										"events"
+									],
+									"query": [
+										{
+											"key": "playerId",
+											"value": "<string>",
+											"description": "The ID of a player that must be the batter or the pitcher in each event.",
+											"disabled": true
+										},
+										{
+											"key": "gameId",
+											"value": "<string>",
+											"description": "The ID of the game by which to filter results.",
+											"disabled": true
+										},
+										{
+											"key": "pitcherId",
+											"value": "<string>",
+											"description": "The ID of the pitcher that must be in each event.",
+											"disabled": true
+										},
+										{
+											"key": "type",
+											"value": "HOME_RUN",
+											"description": "The type of event by which to filter."
+										},
+										{
+											"key": "outcomes",
+											"value": "<boolean>",
+											"description": "Include child player event records.",
+											"disabled": true
+										},
+										{
+											"key": "baseRunners",
+											"value": "<boolean>",
+											"description": "Include child base runner records.",
+											"disabled": true
+										},
+										{
+											"key": "sortBy",
+											"value": "<string>",
+											"description": "The field by which to sort. Most text and numeric columns are supported.",
+											"disabled": true
+										},
+										{
+											"key": "sortDirection",
+											"value": "<string>",
+											"description": "The direction by which to sort. Must be one of ASC, DESC.",
+											"disabled": true
+										},
+										{
+											"key": "batterId",
+											"value": "740d5fef-d59f-4dac-9a75-739ec07f91cf"
+										}
+									]
+								},
+								"description": "Get the list of game events that match the query. One of `playerId`, `gameId`, `pitcherId`, `batterId` must be specified."
+							},
+							"response": [
+								{
+									"name": "The events that match the query and the number of matching events.",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/v1/events?playerId=<string>&gameId=<string>&pitcherId=<string>&batterId=<string>&type=<string>&outcomes=<boolean>&baseRunners=<boolean>&sortBy=<string>&sortDirection=<string>",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"v1",
+												"events"
+											],
+											"query": [
+												{
+													"key": "playerId",
+													"value": "<string>"
+												},
+												{
+													"key": "gameId",
+													"value": "<string>"
+												},
+												{
+													"key": "pitcherId",
+													"value": "<string>"
+												},
+												{
+													"key": "batterId",
+													"value": "<string>"
+												},
+												{
+													"key": "type",
+													"value": "<string>"
+												},
+												{
+													"key": "outcomes",
+													"value": "<boolean>"
+												},
+												{
+													"key": "baseRunners",
+													"value": "<boolean>"
+												},
+												{
+													"key": "sortBy",
+													"value": "<string>"
+												},
+												{
+													"key": "sortDirection",
+													"value": "<string>"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "text",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "text/plain"
+										}
+									],
+									"cookie": [],
+									"body": ""
+								}
+							]
+						},
+						{
+							"name": "Calculate the number of events for each batter or pitcher.",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Same number of dingers\", function () {\r",
+											"    var jsonData = pm.response.json();\r",
+											"    pm.expect(jsonData.batters[0].count === pm.variables.get(\"conner_dingers\"))\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Over 100 pitchers dinged\", function () {\r",
+											"    var jsonData = pm.response.json();\r",
+											"    pm.expect(jsonData.pitchers.length).greaterThan(100);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/v1/countByType?eventType=HOME_RUN&batterId=740d5fef-d59f-4dac-9a75-739ec07f91cf",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"v1",
+										"countByType"
+									],
+									"query": [
+										{
+											"key": "eventType",
+											"value": "HOME_RUN",
+											"description": "(Required) The type of event to count."
+										},
+										{
+											"key": "batterId",
+											"value": "740d5fef-d59f-4dac-9a75-739ec07f91cf",
+											"description": "The ID of the batter(s) by which to filter."
+										},
+										{
+											"key": "pitcherId",
+											"value": "<string>",
+											"description": "The ID of the pitcher(s) by which to filter.",
+											"disabled": true
+										}
+									]
+								},
+								"description": "Get the number of events for a batter or pitcher with a certain `event_type`."
+							},
+							"response": [
+								{
+									"name": "The number of events the batter was involved in with the specified type.",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/v1/countByType?eventType=<string>&batterId=<string>&pitcherId=<string>",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"v1",
+												"countByType"
+											],
+											"query": [
+												{
+													"key": "eventType",
+													"value": "<string>"
+												},
+												{
+													"key": "batterId",
+													"value": "<string>"
+												},
+												{
+													"key": "pitcherId",
+													"value": "<string>"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "text",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "text/plain"
+										}
+									],
+									"cookie": [],
+									"body": ""
+								}
+							]
+						},
+						{
+							"name": "Scorigami",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Over 375 sclorigamis\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    console.log(jsonData.length);",
+											"    pm.expect(jsonData.length).greaterThan(375);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/v1/sclorigami",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"v1",
+										"sclorigami"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "Players",
+					"item": [
+						{
+							"name": "playerInfo",
+							"item": [
+								{
+									"name": "playerInfo by Player ID",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/v1/playerInfo?playerId=740d5fef-d59f-4dac-9a75-739ec07f91cf&all=true",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"v1",
+												"playerInfo"
+											],
+											"query": [
+												{
+													"key": "playerId",
+													"value": "740d5fef-d59f-4dac-9a75-739ec07f91cf"
+												},
+												{
+													"key": "all",
+													"value": "true"
+												},
+												{
+													"key": "name",
+													"value": "<string>",
+													"description": "The name of the player (takes precedence if slug is specified)",
+													"disabled": true
+												},
+												{
+													"key": "slug",
+													"value": "<string>",
+													"description": "The url_slug of the player",
+													"disabled": true
+												}
+											]
+										},
+										"description": "Get extended player info for a given player, given a player id, name, or slug."
+									},
+									"response": [
+										{
+											"name": "array of objects",
+											"originalRequest": {
+												"method": "GET",
+												"header": [],
+												"url": {
+													"raw": "{{baseUrl}}/v1/playerInfo?playerId=<string>&name=<string>&slug=<string>&all=<boolean>",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"v1",
+														"playerInfo"
+													],
+													"query": [
+														{
+															"key": "playerId",
+															"value": "<string>"
+														},
+														{
+															"key": "name",
+															"value": "<string>"
+														},
+														{
+															"key": "slug",
+															"value": "<string>"
+														},
+														{
+															"key": "all",
+															"value": "<boolean>"
+														}
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "text",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "text/plain"
+												}
+											],
+											"cookie": [],
+											"body": ""
+										}
+									]
+								},
+								{
+									"name": "playerInfo by Name",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/v1/playerInfo?name=Conner Haley&all=true",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"v1",
+												"playerInfo"
+											],
+											"query": [
+												{
+													"key": "playerId",
+													"value": "<string>",
+													"description": "The player ID of the player (takes precedence if other params are specified)",
+													"disabled": true
+												},
+												{
+													"key": "name",
+													"value": "Conner Haley",
+													"description": "The name of the player (takes precedence if slug is specified)"
+												},
+												{
+													"key": "slug",
+													"value": "<string>",
+													"description": "The url_slug of the player",
+													"disabled": true
+												},
+												{
+													"key": "all",
+													"value": "true",
+													"description": "(default:false) If true, all historical info for the player will be returned, rather than just the current info"
+												}
+											]
+										},
+										"description": "Get extended player info for a given player, given a player id, name, or slug."
+									},
+									"response": [
+										{
+											"name": "array of objects",
+											"originalRequest": {
+												"method": "GET",
+												"header": [],
+												"url": {
+													"raw": "{{baseUrl}}/v1/playerInfo?playerId=<string>&name=<string>&slug=<string>&all=<boolean>",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"v1",
+														"playerInfo"
+													],
+													"query": [
+														{
+															"key": "playerId",
+															"value": "<string>"
+														},
+														{
+															"key": "name",
+															"value": "<string>"
+														},
+														{
+															"key": "slug",
+															"value": "<string>"
+														},
+														{
+															"key": "all",
+															"value": "<boolean>"
+														}
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "text",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "text/plain"
+												}
+											],
+											"cookie": [],
+											"body": ""
+										}
+									]
+								},
+								{
+									"name": "playerInfo by Slug",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/v1/playerInfo?all=true&slug=conner-haley",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"v1",
+												"playerInfo"
+											],
+											"query": [
+												{
+													"key": "playerId",
+													"value": "<string>",
+													"description": "The player ID of the player (takes precedence if other params are specified)",
+													"disabled": true
+												},
+												{
+													"key": "name",
+													"value": "<string>",
+													"description": "The name of the player (takes precedence if slug is specified)",
+													"disabled": true
+												},
+												{
+													"key": "all",
+													"value": "true",
+													"description": "(default:false) If true, all historical info for the player will be returned, rather than just the current info"
+												},
+												{
+													"key": "slug",
+													"value": "conner-haley"
+												}
+											]
+										},
+										"description": "Get extended player info for a given player, given a player id, name, or slug."
+									},
+									"response": [
+										{
+											"name": "array of objects",
+											"originalRequest": {
+												"method": "GET",
+												"header": [],
+												"url": {
+													"raw": "{{baseUrl}}/v1/playerInfo?playerId=<string>&name=<string>&slug=<string>&all=<boolean>",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"v1",
+														"playerInfo"
+													],
+													"query": [
+														{
+															"key": "playerId",
+															"value": "<string>"
+														},
+														{
+															"key": "name",
+															"value": "<string>"
+														},
+														{
+															"key": "slug",
+															"value": "<string>"
+														},
+														{
+															"key": "all",
+															"value": "<boolean>"
+														}
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "text",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "text/plain"
+												}
+											],
+											"cookie": [],
+											"body": ""
+										}
+									]
+								}
+							],
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"type": "text/javascript",
+										"exec": [
+											""
+										]
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"type": "text/javascript",
+										"exec": [
+											"pm.test(\"More than 1 result\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.length).greaterThan(1);",
+											"});",
+											""
+										]
+									}
+								}
+							]
+						},
+						{
+							"name": "playerIdsByName",
+							"item": [
+								{
+									"name": "playerIdsByName: Wyatt Mason",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"More than 10 results\", function () {\r",
+													"    var jsonData = pm.response.json();\r",
+													"    pm.expect(jsonData.length).greaterThan(10);\r",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/v1/playerIdsByName?name=Wyatt Mason&current=false",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"v1",
+												"playerIdsByName"
+											],
+											"query": [
+												{
+													"key": "name",
+													"value": "Wyatt Mason",
+													"description": "The name of the player"
+												},
+												{
+													"key": "current",
+													"value": "false",
+													"description": "If true, only players currently using this name will be returned"
+												}
+											]
+										},
+										"description": "Get all player IDs matching a given name"
+									},
+									"response": [
+										{
+											"name": "Wyatt Mason",
+											"originalRequest": {
+												"method": "GET",
+												"header": [],
+												"url": {
+													"raw": "{{baseUrl}}/v1/playerIdsByName?name=Wyatt Mason&current=false",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"v1",
+														"playerIdsByName"
+													],
+													"query": [
+														{
+															"key": "name",
+															"value": "Wyatt Mason",
+															"description": "The name of the player"
+														},
+														{
+															"key": "current",
+															"value": "false",
+															"description": "If true, only players currently using this name will be returned"
+														}
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Server",
+													"value": "nginx/1.19.1"
+												},
+												{
+													"key": "Date",
+													"value": "Sat, 28 Nov 2020 03:56:02 GMT"
+												},
+												{
+													"key": "Content-Type",
+													"value": "application/json; charset=utf-8"
+												},
+												{
+													"key": "Content-Length",
+													"value": "2431"
+												},
+												{
+													"key": "Connection",
+													"value": "keep-alive"
+												},
+												{
+													"key": "X-Powered-By",
+													"value": "Express"
+												},
+												{
+													"key": "Access-Control-Allow-Origin",
+													"value": "*"
+												},
+												{
+													"key": "ETag",
+													"value": "W/\"97f-LVEvqdJXFDbfuURjGB1yAmWRUkY\""
+												}
+											],
+											"cookie": [],
+											"body": "[\n    {\n        \"player_id\": \"0bb35615-63f2-4492-80ec-b6b322dc5450\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:25:43.399Z\"\n    },\n    {\n        \"player_id\": \"0d5300f6-0966-430f-903f-a4c2338abf00\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:55:48.749Z\"\n    },\n    {\n        \"player_id\": \"1f159bab-923a-4811-b6fa-02bfde50925a\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:25:43.399Z\"\n    },\n    {\n        \"player_id\": \"21d52455-6c2c-4ee4-8673-ab46b4b926b4\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:25:43.399Z\"\n    },\n    {\n        \"player_id\": \"27c68d7f-5e40-4afa-8b6f-9df47b79e7dd\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:25:43.399Z\"\n    },\n    {\n        \"player_id\": \"5ca7e854-dc00-4955-9235-d7fcd732ddcf\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:25:43.399Z\"\n    },\n    {\n        \"player_id\": \"63df8701-1871-4987-87d7-b55d4f1df2e9\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T22:10:51.203Z\"\n    },\n    {\n        \"player_id\": \"75f9d874-5e69-438d-900d-a3fcb1d429b3\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:10:40.842Z\"\n    },\n    {\n        \"player_id\": \"80e474a3-7d2b-431d-8192-2f1e27162607\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-12T20:25:34.306Z\",\n        \"valid_until\": \"2020-08-12T20:40:36.879Z\"\n    },\n    {\n        \"player_id\": \"a1ed3396-114a-40bc-9ff0-54d7e1ad1718\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T20:55:38.256Z\"\n    },\n    {\n        \"player_id\": \"bf6a24d1-4e89-4790-a4ba-eeb2870cbf6f\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:40:45.977Z\"\n    },\n    {\n        \"player_id\": \"e16c3f28-eecd-4571-be1a-606bbac36b2b\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T20:55:38.256Z\"\n    },\n    {\n        \"player_id\": \"e4034192-4dc6-4901-bb30-07fe3cf77b5e\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:25:43.399Z\"\n    },\n    {\n        \"player_id\": \"ea44bd36-65b4-4f3b-ac71-78d87a540b48\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:40:45.977Z\"\n    },\n    {\n        \"player_id\": \"f741dc01-2bae-4459-bfc0-f97536193eea\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:25:43.399Z\"\n    }\n]"
+										}
+									]
+								},
+								{
+									"name": "playerIdsByName: Valid Player",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Single result\", function () {\r",
+													"    var jsonData = pm.response.json();\r",
+													"    pm.expect(jsonData.length).to.eql(1);\r",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/v1/playerIdsByName?name=Conner Haley&current=true",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"v1",
+												"playerIdsByName"
+											],
+											"query": [
+												{
+													"key": "name",
+													"value": "Conner Haley",
+													"description": "The name of the player"
+												},
+												{
+													"key": "current",
+													"value": "true",
+													"description": "If true, only players currently using this name will be returned"
+												}
+											]
+										},
+										"description": "Get all player IDs matching a given name"
+									},
+									"response": [
+										{
+											"name": "Wyatt Mason",
+											"originalRequest": {
+												"method": "GET",
+												"header": [],
+												"url": {
+													"raw": "{{baseUrl}}/v1/playerIdsByName?name=Wyatt Mason&current=false",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"v1",
+														"playerIdsByName"
+													],
+													"query": [
+														{
+															"key": "name",
+															"value": "Wyatt Mason",
+															"description": "The name of the player"
+														},
+														{
+															"key": "current",
+															"value": "false",
+															"description": "If true, only players currently using this name will be returned"
+														}
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Server",
+													"value": "nginx/1.19.1"
+												},
+												{
+													"key": "Date",
+													"value": "Sat, 28 Nov 2020 03:56:02 GMT"
+												},
+												{
+													"key": "Content-Type",
+													"value": "application/json; charset=utf-8"
+												},
+												{
+													"key": "Content-Length",
+													"value": "2431"
+												},
+												{
+													"key": "Connection",
+													"value": "keep-alive"
+												},
+												{
+													"key": "X-Powered-By",
+													"value": "Express"
+												},
+												{
+													"key": "Access-Control-Allow-Origin",
+													"value": "*"
+												},
+												{
+													"key": "ETag",
+													"value": "W/\"97f-LVEvqdJXFDbfuURjGB1yAmWRUkY\""
+												}
+											],
+											"cookie": [],
+											"body": "[\n    {\n        \"player_id\": \"0bb35615-63f2-4492-80ec-b6b322dc5450\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:25:43.399Z\"\n    },\n    {\n        \"player_id\": \"0d5300f6-0966-430f-903f-a4c2338abf00\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:55:48.749Z\"\n    },\n    {\n        \"player_id\": \"1f159bab-923a-4811-b6fa-02bfde50925a\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:25:43.399Z\"\n    },\n    {\n        \"player_id\": \"21d52455-6c2c-4ee4-8673-ab46b4b926b4\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:25:43.399Z\"\n    },\n    {\n        \"player_id\": \"27c68d7f-5e40-4afa-8b6f-9df47b79e7dd\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:25:43.399Z\"\n    },\n    {\n        \"player_id\": \"5ca7e854-dc00-4955-9235-d7fcd732ddcf\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:25:43.399Z\"\n    },\n    {\n        \"player_id\": \"63df8701-1871-4987-87d7-b55d4f1df2e9\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T22:10:51.203Z\"\n    },\n    {\n        \"player_id\": \"75f9d874-5e69-438d-900d-a3fcb1d429b3\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:10:40.842Z\"\n    },\n    {\n        \"player_id\": \"80e474a3-7d2b-431d-8192-2f1e27162607\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-12T20:25:34.306Z\",\n        \"valid_until\": \"2020-08-12T20:40:36.879Z\"\n    },\n    {\n        \"player_id\": \"a1ed3396-114a-40bc-9ff0-54d7e1ad1718\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T20:55:38.256Z\"\n    },\n    {\n        \"player_id\": \"bf6a24d1-4e89-4790-a4ba-eeb2870cbf6f\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:40:45.977Z\"\n    },\n    {\n        \"player_id\": \"e16c3f28-eecd-4571-be1a-606bbac36b2b\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T20:55:38.256Z\"\n    },\n    {\n        \"player_id\": \"e4034192-4dc6-4901-bb30-07fe3cf77b5e\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:25:43.399Z\"\n    },\n    {\n        \"player_id\": \"ea44bd36-65b4-4f3b-ac71-78d87a540b48\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:40:45.977Z\"\n    },\n    {\n        \"player_id\": \"f741dc01-2bae-4459-bfc0-f97536193eea\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:25:43.399Z\"\n    }\n]"
+										}
+									]
+								},
+								{
+									"name": "playerIdsByName: Invalid Player",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Expected no results\", function () {\r",
+													"    var jsonData = pm.response.json();\r",
+													"    pm.expect(jsonData.length).to.eql(0);\r",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/v1/playerIdsByName?name=Fakey McFakeName&current=true",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"v1",
+												"playerIdsByName"
+											],
+											"query": [
+												{
+													"key": "name",
+													"value": "Fakey McFakeName",
+													"description": "The name of the player"
+												},
+												{
+													"key": "current",
+													"value": "true",
+													"description": "If true, only players currently using this name will be returned"
+												}
+											]
+										},
+										"description": "Get all player IDs matching a given name"
+									},
+									"response": [
+										{
+											"name": "Wyatt Mason",
+											"originalRequest": {
+												"method": "GET",
+												"header": [],
+												"url": {
+													"raw": "{{baseUrl}}/v1/playerIdsByName?name=Wyatt Mason&current=false",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"v1",
+														"playerIdsByName"
+													],
+													"query": [
+														{
+															"key": "name",
+															"value": "Wyatt Mason",
+															"description": "The name of the player"
+														},
+														{
+															"key": "current",
+															"value": "false",
+															"description": "If true, only players currently using this name will be returned"
+														}
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Server",
+													"value": "nginx/1.19.1"
+												},
+												{
+													"key": "Date",
+													"value": "Sat, 28 Nov 2020 03:56:02 GMT"
+												},
+												{
+													"key": "Content-Type",
+													"value": "application/json; charset=utf-8"
+												},
+												{
+													"key": "Content-Length",
+													"value": "2431"
+												},
+												{
+													"key": "Connection",
+													"value": "keep-alive"
+												},
+												{
+													"key": "X-Powered-By",
+													"value": "Express"
+												},
+												{
+													"key": "Access-Control-Allow-Origin",
+													"value": "*"
+												},
+												{
+													"key": "ETag",
+													"value": "W/\"97f-LVEvqdJXFDbfuURjGB1yAmWRUkY\""
+												}
+											],
+											"cookie": [],
+											"body": "[\n    {\n        \"player_id\": \"0bb35615-63f2-4492-80ec-b6b322dc5450\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:25:43.399Z\"\n    },\n    {\n        \"player_id\": \"0d5300f6-0966-430f-903f-a4c2338abf00\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:55:48.749Z\"\n    },\n    {\n        \"player_id\": \"1f159bab-923a-4811-b6fa-02bfde50925a\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:25:43.399Z\"\n    },\n    {\n        \"player_id\": \"21d52455-6c2c-4ee4-8673-ab46b4b926b4\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:25:43.399Z\"\n    },\n    {\n        \"player_id\": \"27c68d7f-5e40-4afa-8b6f-9df47b79e7dd\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:25:43.399Z\"\n    },\n    {\n        \"player_id\": \"5ca7e854-dc00-4955-9235-d7fcd732ddcf\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:25:43.399Z\"\n    },\n    {\n        \"player_id\": \"63df8701-1871-4987-87d7-b55d4f1df2e9\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T22:10:51.203Z\"\n    },\n    {\n        \"player_id\": \"75f9d874-5e69-438d-900d-a3fcb1d429b3\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:10:40.842Z\"\n    },\n    {\n        \"player_id\": \"80e474a3-7d2b-431d-8192-2f1e27162607\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-12T20:25:34.306Z\",\n        \"valid_until\": \"2020-08-12T20:40:36.879Z\"\n    },\n    {\n        \"player_id\": \"a1ed3396-114a-40bc-9ff0-54d7e1ad1718\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T20:55:38.256Z\"\n    },\n    {\n        \"player_id\": \"bf6a24d1-4e89-4790-a4ba-eeb2870cbf6f\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:40:45.977Z\"\n    },\n    {\n        \"player_id\": \"e16c3f28-eecd-4571-be1a-606bbac36b2b\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T20:55:38.256Z\"\n    },\n    {\n        \"player_id\": \"e4034192-4dc6-4901-bb30-07fe3cf77b5e\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:25:43.399Z\"\n    },\n    {\n        \"player_id\": \"ea44bd36-65b4-4f3b-ac71-78d87a540b48\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:40:45.977Z\"\n    },\n    {\n        \"player_id\": \"f741dc01-2bae-4459-bfc0-f97536193eea\",\n        \"player_name\": \"Wyatt Mason\",\n        \"valid_from\": \"2020-08-09T19:27:41.958Z\",\n        \"valid_until\": \"2020-08-12T21:25:43.399Z\"\n    }\n]"
+										}
+									]
+								}
+							]
+						},
+						{
+							"name": "deceased",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/v1/deceased",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"v1",
+										"deceased"
+									]
+								},
+								"description": "Get all currently decieased players"
+							},
+							"response": [
+								{
+									"name": "Array of player objects",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/v1/deceased",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"v1",
+												"deceased"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "text",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "text/plain"
+										}
+									],
+									"cookie": [],
+									"body": ""
+								}
+							]
+						},
+						{
+							"name": "taggedPlayers",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"More than 5 tagged players\", function () {\r",
+											"    var jsonData = pm.response.json();\r",
+											"    pm.expect(jsonData.length).greaterThan(5);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/v1/taggedPlayers",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"v1",
+										"taggedPlayers"
+									]
+								},
+								"description": "Get the list of all players currently tagged with some kind of modification (like SHELLED)"
+							},
+							"response": [
+								{
+									"name": "array of player information including current team id/nickname",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/v1/taggedPlayers",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"v1",
+												"taggedPlayers"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "text",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "text/plain"
+										}
+									],
+									"cookie": [],
+									"body": ""
+								}
+							]
+						},
+						{
+							"name": "allPlayers (no shadows)",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"\r",
+											"pm.test(\"Greater than 200 players\", function () {\r",
+											"    var jsonData = pm.response.json();\r",
+											"    pm.expect(jsonData.length).greaterThan(200);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/v1/allPlayers?includeShadows=false",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"v1",
+										"allPlayers"
+									],
+									"query": [
+										{
+											"key": "includeShadows",
+											"value": "false",
+											"description": "whether to include players in the Shadows"
+										}
+									]
+								},
+								"description": "Get the current list of all known players"
+							},
+							"response": [
+								{
+									"name": "list of players",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/v1/allPlayers?includeShadows=<boolean>",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"v1",
+												"allPlayers"
+											],
+											"query": [
+												{
+													"key": "includeShadows",
+													"value": "<boolean>"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "text",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "text/plain"
+										}
+									],
+									"cookie": [],
+									"body": ""
+								}
+							]
+						},
+						{
+							"name": "allPlayersForGameday S10D10",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Should get >300 players for S10D10\", function () {\r",
+											"    var jsonData = pm.response.json();\r",
+											"    pm.expect(jsonData.length).greaterThan(300);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/v1/allPlayersForGameday?season=10&day=10",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"v1",
+										"allPlayersForGameday"
+									],
+									"query": [
+										{
+											"key": "season",
+											"value": "10",
+											"description": "Season to query (zero-indexed)"
+										},
+										{
+											"key": "day",
+											"value": "10",
+											"description": "Day to query (zero-indexed)"
+										}
+									]
+								},
+								"description": "Get the list of all players and their data as of a specific Season and Gameday"
+							},
+							"response": [
+								{
+									"name": "array of player information including current team id/nickname",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/v1/allPlayersForGameday?season=<number>&day=<number>",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"v1",
+												"allPlayersForGameday"
+											],
+											"query": [
+												{
+													"key": "season",
+													"value": "<number>"
+												},
+												{
+													"key": "day",
+													"value": "<number>"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "text",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "text/plain"
+										}
+									],
+									"cookie": [],
+									"body": ""
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "Statistics",
+					"item": [
+						{
+							"name": "Get the season leaders for a given category and stat",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Your test name\", function () {\r",
+											"    var jsonData = pm.response.json();\r",
+											"    pm.expect(jsonData.length).to.eql(10);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/v1/seasonLeaders?season=9&category=batting&stat=home_runs&order=DESC&limit=10",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"v1",
+										"seasonLeaders"
+									],
+									"query": [
+										{
+											"key": "season",
+											"value": "9",
+											"description": "Season to query (zero-indexed)"
+										},
+										{
+											"key": "category",
+											"value": "batting",
+											"description": "Stat category (batting, pitching, running, or fielding)"
+										},
+										{
+											"key": "stat",
+											"value": "home_runs",
+											"description": "Stat to get the leaders for (as returned from /playerStats)"
+										},
+										{
+											"key": "order",
+											"value": "DESC",
+											"description": "Ordering to use for ranking (ASC or DESC)"
+										},
+										{
+											"key": "limit",
+											"value": "10",
+											"description": "Number of leaders to return"
+										}
+									]
+								},
+								"description": "Get the season leaders for a given category and stat"
+							},
+							"response": [
+								{
+									"name": "list of leaders",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/v1/seasonLeaders?season=<number>&category=<string>&stat=<string>&order=<string>&limit=<number>",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"v1",
+												"seasonLeaders"
+											],
+											"query": [
+												{
+													"key": "season",
+													"value": "<number>"
+												},
+												{
+													"key": "category",
+													"value": "<string>"
+												},
+												{
+													"key": "stat",
+													"value": "<string>"
+												},
+												{
+													"key": "order",
+													"value": "<string>"
+												},
+												{
+													"key": "limit",
+													"value": "<number>"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "text",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "text/plain"
+										}
+									],
+									"cookie": [],
+									"body": ""
+								}
+							]
+						},
+						{
+							"name": "Get categorical statistics for the given players",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Exactly 1 result\", function () {\r",
+											"    var jsonData = pm.response.json();\r",
+											"    pm.expect(jsonData.length).to.eql(1);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/v1/playerStats?category=batting&season=9&playerIds=740d5fef-d59f-4dac-9a75-739ec07f91cf",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"v1",
+										"playerStats"
+									],
+									"query": [
+										{
+											"key": "category",
+											"value": "batting",
+											"description": "either 'batting' or 'pitching'"
+										},
+										{
+											"key": "season",
+											"value": "9",
+											"description": "(optional) season to get stats for"
+										},
+										{
+											"key": "playerIds",
+											"value": "740d5fef-d59f-4dac-9a75-739ec07f91cf",
+											"description": "comma-separated list of player IDs"
+										}
+									]
+								},
+								"description": "Get performance statistics for a given list of players"
+							},
+							"response": [
+								{
+									"name": "list of player statistics",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/v1/playerStats?category=<string>&season=<number>&playerIds=<string>",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"v1",
+												"playerStats"
+											],
+											"query": [
+												{
+													"key": "category",
+													"value": "<string>"
+												},
+												{
+													"key": "season",
+													"value": "<number>"
+												},
+												{
+													"key": "playerIds",
+													"value": "<string>"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "text",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "text/plain"
+										}
+									],
+									"cookie": [],
+									"body": ""
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "Teams",
+					"item": [
+						{
+							"name": "currentRoster",
+							"item": [
+								{
+									"name": "currentRoster by teamId",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/v1/currentRoster?teamId=b024e975-1c4a-4575-8936-a3754a08806a",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"v1",
+												"currentRoster"
+											],
+											"query": [
+												{
+													"key": "teamId",
+													"value": "b024e975-1c4a-4575-8936-a3754a08806a",
+													"description": "The ID of the team (takes precedence if slug is given)"
+												},
+												{
+													"key": "slug",
+													"value": "<string>",
+													"description": "The slug of the team",
+													"disabled": true
+												}
+											]
+										},
+										"description": "Get the current roster for a given team, using either ID or slug."
+									},
+									"response": [
+										{
+											"name": "array of roster information",
+											"originalRequest": {
+												"method": "GET",
+												"header": [],
+												"url": {
+													"raw": "{{baseUrl}}/v1/currentRoster?teamId=<string>&slug=<string>",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"v1",
+														"currentRoster"
+													],
+													"query": [
+														{
+															"key": "teamId",
+															"value": "<string>"
+														},
+														{
+															"key": "slug",
+															"value": "<string>"
+														}
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "text",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "text/plain"
+												}
+											],
+											"cookie": [],
+											"body": ""
+										}
+									]
+								},
+								{
+									"name": "currentRoster by slug",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/v1/currentRoster?slug=steaks",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"v1",
+												"currentRoster"
+											],
+											"query": [
+												{
+													"key": "teamId",
+													"value": "<string>",
+													"description": "The ID of the team (takes precedence if slug is given)",
+													"disabled": true
+												},
+												{
+													"key": "slug",
+													"value": "steaks",
+													"description": "The slug of the team"
+												}
+											]
+										},
+										"description": "Get the current roster for a given team, using either ID or slug."
+									},
+									"response": [
+										{
+											"name": "array of roster information",
+											"originalRequest": {
+												"method": "GET",
+												"header": [],
+												"url": {
+													"raw": "{{baseUrl}}/v1/currentRoster?teamId=<string>&slug=<string>",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"v1",
+														"currentRoster"
+													],
+													"query": [
+														{
+															"key": "teamId",
+															"value": "<string>"
+														},
+														{
+															"key": "slug",
+															"value": "<string>"
+														}
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "text",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "text/plain"
+												}
+											],
+											"cookie": [],
+											"body": ""
+										}
+									]
+								}
+							],
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"type": "text/javascript",
+										"exec": [
+											""
+										]
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"type": "text/javascript",
+										"exec": [
+											"pm.test(\"More than one player\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.length).greaterThan(1);",
+											"});"
+										]
+									}
+								}
+							]
+						},
+						{
+							"name": "allTeams",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"\r",
+											"pm.test(\"More than 36 teams\", function () {\r",
+											"    var jsonData = pm.response.json();\r",
+											"    pm.expect(jsonData.length).greaterThan(36);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/v1/allTeams",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"v1",
+										"allTeams"
+									]
+								},
+								"description": "Get all current teams"
+							},
+							"response": [
+								{
+									"name": "list of current teams",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/v1/allTeams",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"v1",
+												"allTeams"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "text",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "text/plain"
+										}
+									],
+									"cookie": [],
+									"body": ""
+								}
+							]
+						},
+						{
+							"name": "allTeamStars",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"\r",
+											"pm.test(\"More than 23 teams\", function () {\r",
+											"    var jsonData = pm.response.json();\r",
+											"    pm.expect(jsonData.length).greaterThan(23);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/v1/allTeamStars",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"v1",
+										"allTeamStars"
+									]
+								},
+								"description": "Get current star values for all teams"
+							},
+							"response": [
+								{
+									"name": "list of current team stars",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/v1/allTeamStars",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"v1",
+												"allTeamStars"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "text",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "text/plain"
+										}
+									],
+									"cookie": [],
+									"body": ""
+								}
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "v2",
+			"item": [
+				{
+					"name": "Teams",
+					"item": [
+						{
+							"name": "/teams",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"should respond with 20 teams for season 7\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.length).to.equal(20);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"pm.collectionVariables.set(\"season\", \"7\");",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/v2/teams?season={{season}}",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"v2",
+										"teams"
+									],
+									"query": [
+										{
+											"key": "season",
+											"value": "{{season}}",
+											"description": "The (0-indexed) Blaseball season (or `current` for current season)"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "Numbered Season Teams",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/v2/teams?season=7",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"v2",
+												"teams"
+											],
+											"query": [
+												{
+													"key": "season",
+													"value": "7",
+													"description": "The (0-indexed) Blaseball season (or `current` for current season)"
+												}
+											]
+										}
+									},
+									"status": "Not Found",
+									"code": 404,
+									"_postman_previewlanguage": "html",
+									"header": [
+										{
+											"key": "X-Powered-By",
+											"value": "Express"
+										},
+										{
+											"key": "Access-Control-Allow-Origin",
+											"value": "*"
+										},
+										{
+											"key": "Content-Security-Policy",
+											"value": "default-src 'none'"
+										},
+										{
+											"key": "X-Content-Type-Options",
+											"value": "nosniff"
+										},
+										{
+											"key": "Content-Type",
+											"value": "text/html; charset=utf-8"
+										},
+										{
+											"key": "Content-Length",
+											"value": "150"
+										},
+										{
+											"key": "Date",
+											"value": "Sat, 20 Feb 2021 18:32:44 GMT"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "Keep-Alive",
+											"value": "timeout=5"
+										}
+									],
+									"cookie": [],
+									"body": "<!DOCTYPE html>\n<html lang=\"en\">\n    <head>\n        <meta charset=\"utf-8\">\n        <title>Error</title>\n    </head>\n    <body>\n        <pre>Cannot GET /v1/v2/teams</pre>\n    </body>\n</html>"
+								},
+								{
+									"name": "Current Season Teams",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/v2/teams?season=current",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"v2",
+												"teams"
+											],
+											"query": [
+												{
+													"key": "season",
+													"value": "current",
+													"description": "The (0-indexed) Blaseball season (or `current` for current season)"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "X-Powered-By",
+											"value": "Express"
+										},
+										{
+											"key": "Access-Control-Allow-Origin",
+											"value": "*"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json; charset=utf-8"
+										},
+										{
+											"key": "Content-Length",
+											"value": "13019"
+										},
+										{
+											"key": "ETag",
+											"value": "W/\"32db-3HelBESZuv/pvWlTIlGOxnPbQl4\""
+										},
+										{
+											"key": "Date",
+											"value": "Sat, 20 Feb 2021 19:01:41 GMT"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "Keep-Alive",
+											"value": "timeout=5"
+										}
+									],
+									"cookie": [],
+									"body": "[\n    {\n        \"team_id\": \"105bc3ff-1320-4e37-8ef0-8d595cb95dd0\",\n        \"location\": \"Seattle\",\n        \"nickname\": \"Garages\",\n        \"full_name\": \"Seattle Garages\",\n        \"team_abbreviation\": \"SEA\",\n        \"url_slug\": \"garages\",\n        \"current_team_status\": \"active\",\n        \"valid_from\": \"2020-09-20T19:15:35.880Z\",\n        \"valid_until\": \"2020-09-27T01:24:03.154Z\",\n        \"gameday_from\": null,\n        \"season_from\": 6,\n        \"division\": \"Mild High\",\n        \"division_id\": \"456089f0-f338-4620-a014-9540868789c9\",\n        \"league\": \"Mild\",\n        \"league_id\": \"4fe65afa-804f-4bb2-9b15-1281b2eab110\",\n        \"tournament_name\": null,\n        \"modifications\": [\n            \"BLOOD_DONOR\",\n            \"SHAME_PIT\"\n        ],\n        \"team_main_color\": \"#2b4075\",\n        \"team_secondary_color\": \"#5a83ea\",\n        \"team_slogan\": \"Smells like Team Spirit.\",\n        \"team_emoji\": \"0x1F3B8\"\n    },\n    {\n        \"team_id\": \"23e4cbc1-e9cd-47fa-a35b-bfa06f726cb7\",\n        \"location\": \"Philly\",\n        \"nickname\": \"Pies\",\n        \"full_name\": \"Philly Pies\",\n        \"team_abbreviation\": \"PIES\",\n        \"url_slug\": \"pies\",\n        \"current_team_status\": \"active\",\n        \"valid_from\": \"2020-09-06T19:00:36.117Z\",\n        \"valid_until\": \"2020-09-27T19:00:06.043Z\",\n        \"gameday_from\": null,\n        \"season_from\": 4,\n        \"division\": \"Mild Low\",\n        \"division_id\": \"fadc9684-45b3-47a6-b647-3be3f0735a84\",\n        \"league\": \"Mild\",\n        \"league_id\": \"4fe65afa-804f-4bb2-9b15-1281b2eab110\",\n        \"tournament_name\": null,\n        \"modifications\": [\n            \"BLOOD_THIEF\"\n        ],\n        \"team_main_color\": \"#399d8f\",\n        \"team_secondary_color\": \"#58c3b4\",\n        \"team_slogan\": \"Pie or Die.\",\n        \"team_emoji\": \"0x1F967\"\n    },\n    {\n        \"team_id\": \"36569151-a2fb-43c1-9df7-2df512424c82\",\n        \"location\": \"New York\",\n        \"nickname\": \"Millennials\",\n        \"full_name\": \"New York Millennials\",\n        \"team_abbreviation\": \"NYM\",\n        \"url_slug\": \"millennials\",\n        \"current_team_status\": \"active\",\n        \"valid_from\": \"2020-09-20T19:15:35.880Z\",\n        \"valid_until\": \"2020-09-27T01:24:03.154Z\",\n        \"gameday_from\": null,\n        \"season_from\": 6,\n        \"division\": \"Wild High\",\n        \"division_id\": \"d4cc18de-a136-4271-84f1-32516be91a80\",\n        \"league\": \"Wild\",\n        \"league_id\": \"aabc11a1-81af-4036-9f18-229c759ca8a9\",\n        \"tournament_name\": null,\n        \"modifications\": [\n            \"BLOOD_PITY\",\n            \"SHAME_PIT\"\n        ],\n        \"team_main_color\": \"#ffd4d8\",\n        \"team_secondary_color\": \"#ffd4d8\",\n        \"team_slogan\": \"Youth Will Save Us\",\n        \"team_emoji\": \"0x1F4F1\"\n    },\n    {\n        \"team_id\": \"3f8bbb15-61c0-4e3f-8e4a-907a5fb1565e\",\n        \"location\": \"Boston\",\n        \"nickname\": \"Flowers\",\n        \"full_name\": \"Boston Flowers\",\n        \"team_abbreviation\": \"BOS\",\n        \"url_slug\": \"flowers\",\n        \"current_team_status\": \"active\",\n        \"valid_from\": \"2020-09-20T19:15:35.880Z\",\n        \"valid_until\": \"2020-09-27T01:24:03.154Z\",\n        \"gameday_from\": null,\n        \"season_from\": 6,\n        \"division\": \"Wild Low\",\n        \"division_id\": \"98c92da4-0ea7-43be-bd75-c6150e184326\",\n        \"league\": \"Wild\",\n        \"league_id\": \"aabc11a1-81af-4036-9f18-229c759ca8a9\",\n        \"tournament_name\": null,\n        \"modifications\": [\n            \"BLOOD_WINNER\",\n            \"SHAME_PIT\"\n        ],\n        \"team_main_color\": \"#f7d1ff\",\n        \"team_secondary_color\": \"#f7d1ff\",\n        \"team_slogan\": \"Bloom Goes The Dynamite!\",\n        \"team_emoji\": \"0x1F339\"\n    },\n    {\n        \"team_id\": \"57ec08cc-0411-4643-b304-0e80dbc15ac7\",\n        \"location\": \"Mexico City\",\n        \"nickname\": \"Wild Wings\",\n        \"full_name\": \"Mexico City Wild Wings\",\n        \"team_abbreviation\": \"CDMX\",\n        \"url_slug\": \"wild-wings\",\n        \"current_team_status\": \"active\",\n        \"valid_from\": \"2020-09-19T19:43:08.648Z\",\n        \"valid_until\": \"2020-10-11T19:00:07.710Z\",\n        \"gameday_from\": 105,\n        \"season_from\": 6,\n        \"division\": \"Mild Low\",\n        \"division_id\": \"fadc9684-45b3-47a6-b647-3be3f0735a84\",\n        \"league\": \"Mild\",\n        \"league_id\": \"4fe65afa-804f-4bb2-9b15-1281b2eab110\",\n        \"tournament_name\": null,\n        \"modifications\": [\n            \"BLOOD_THIEF\"\n        ],\n        \"team_main_color\": \"#d15700\",\n        \"team_secondary_color\": \"#ee6300\",\n        \"team_slogan\": \"Wings. Beer. Blaseball.\",\n        \"team_emoji\": \"0x1F357\"\n    },\n    {\n        \"team_id\": \"747b8e4a-7e50-4638-a973-ea7950a3e739\",\n        \"location\": \"Hades\",\n        \"nickname\": \"Tigers\",\n        \"full_name\": \"Hades Tigers\",\n        \"team_abbreviation\": \"TGRS\",\n        \"url_slug\": \"tigers\",\n        \"current_team_status\": \"active\",\n        \"valid_from\": \"2020-09-20T19:15:35.880Z\",\n        \"valid_until\": \"2020-09-27T01:24:03.154Z\",\n        \"gameday_from\": null,\n        \"season_from\": 6,\n        \"division\": \"Mild High\",\n        \"division_id\": \"456089f0-f338-4620-a014-9540868789c9\",\n        \"league\": \"Mild\",\n        \"league_id\": \"4fe65afa-804f-4bb2-9b15-1281b2eab110\",\n        \"tournament_name\": null,\n        \"modifications\": [\n            \"BLOOD_DONOR\",\n            \"SHAME_PIT\"\n        ],\n        \"team_main_color\": \"#5c1c1c\",\n        \"team_secondary_color\": \"#e83622\",\n        \"team_slogan\": \"Never Look Back.\",\n        \"team_emoji\": \"0x1F405\"\n    },\n    {\n        \"team_id\": \"7966eb04-efcc-499b-8f03-d13916330531\",\n        \"location\": \"Yellowstone\",\n        \"nickname\": \"Magic\",\n        \"full_name\": \"Yellowstone Magic\",\n        \"team_abbreviation\": \"YELL\",\n        \"url_slug\": \"magic\",\n        \"current_team_status\": \"active\",\n        \"valid_from\": \"2020-09-06T19:00:36.117Z\",\n        \"valid_until\": \"2020-10-11T19:00:07.710Z\",\n        \"gameday_from\": null,\n        \"season_from\": 4,\n        \"division\": \"Mild Low\",\n        \"division_id\": \"fadc9684-45b3-47a6-b647-3be3f0735a84\",\n        \"league\": \"Mild\",\n        \"league_id\": \"4fe65afa-804f-4bb2-9b15-1281b2eab110\",\n        \"tournament_name\": null,\n        \"modifications\": [\n            \"BLOOD_THIEF\"\n        ],\n        \"team_main_color\": \"#bf0043\",\n        \"team_secondary_color\": \"#f60f63\",\n        \"team_slogan\": \"As Above, So Below\",\n        \"team_emoji\": \"0x2728\"\n    },\n    {\n        \"team_id\": \"878c1bf6-0d21-4659-bfee-916c8314d69c\",\n        \"location\": \"Unlimited\",\n        \"nickname\": \"Tacos\",\n        \"full_name\": \"Unlimited Tacos\",\n        \"team_abbreviation\": \"TACO\",\n        \"url_slug\": \"tacos\",\n        \"current_team_status\": \"active\",\n        \"valid_from\": \"2020-09-20T19:15:35.880Z\",\n        \"valid_until\": \"2020-09-27T01:24:03.154Z\",\n        \"gameday_from\": null,\n        \"season_from\": 6,\n        \"division\": \"Wild Low\",\n        \"division_id\": \"98c92da4-0ea7-43be-bd75-c6150e184326\",\n        \"league\": \"Wild\",\n        \"league_id\": \"aabc11a1-81af-4036-9f18-229c759ca8a9\",\n        \"tournament_name\": null,\n        \"modifications\": [\n            \"BLOOD_WINNER\",\n            \"SHAME_PIT\"\n        ],\n        \"team_main_color\": \"#64376e\",\n        \"team_secondary_color\": \"#b063c1\",\n        \"team_slogan\": \"72° and Infinite\",\n        \"team_emoji\": \"0x1F32E\"\n    },\n    {\n        \"team_id\": \"8d87c468-699a-47a8-b40d-cfb73a5660ad\",\n        \"location\": \"Baltimore\",\n        \"nickname\": \"Crabs\",\n        \"full_name\": \"Baltimore Crabs\",\n        \"team_abbreviation\": \"CRAB\",\n        \"url_slug\": \"crabs\",\n        \"current_team_status\": \"ascended\",\n        \"valid_from\": \"2020-09-20T19:15:35.880Z\",\n        \"valid_until\": \"2020-09-27T01:24:03.154Z\",\n        \"gameday_from\": null,\n        \"season_from\": 6,\n        \"division\": \"Wild High\",\n        \"division_id\": \"d4cc18de-a136-4271-84f1-32516be91a80\",\n        \"league\": \"Wild\",\n        \"league_id\": \"aabc11a1-81af-4036-9f18-229c759ca8a9\",\n        \"tournament_name\": null,\n        \"modifications\": [\n            \"BLOOD_PITY\",\n            \"SHAME_PIT\"\n        ],\n        \"team_main_color\": \"#593037\",\n        \"team_secondary_color\": \"#b05c6b\",\n        \"team_slogan\": \"Claws Up!\",\n        \"team_emoji\": \"0x1F980\"\n    },\n    {\n        \"team_id\": \"979aee4a-6d80-4863-bf1c-ee1a78e06024\",\n        \"location\": \"Hawaii\",\n        \"nickname\": \"Fridays\",\n        \"full_name\": \"Hawaii Fridays\",\n        \"team_abbreviation\": \"FRI\",\n        \"url_slug\": \"fridays\",\n        \"current_team_status\": \"active\",\n        \"valid_from\": \"2020-09-12T23:23:48.074Z\",\n        \"valid_until\": \"2020-10-08T17:44:21.421Z\",\n        \"gameday_from\": 109,\n        \"season_from\": 5,\n        \"division\": \"Mild Low\",\n        \"division_id\": \"fadc9684-45b3-47a6-b647-3be3f0735a84\",\n        \"league\": \"Mild\",\n        \"league_id\": \"4fe65afa-804f-4bb2-9b15-1281b2eab110\",\n        \"tournament_name\": null,\n        \"modifications\": [\n            \"BLOOD_THIEF\"\n        ],\n        \"team_main_color\": \"#3ee652\",\n        \"team_secondary_color\": \"#3ee652\",\n        \"team_slogan\": \"It's Island Time!\",\n        \"team_emoji\": \"0x1F3DD\"\n    },\n    {\n        \"team_id\": \"9debc64f-74b7-4ae1-a4d6-fce0144b6ea5\",\n        \"location\": \"Houston\",\n        \"nickname\": \"Spies\",\n        \"full_name\": \"Houston Spies\",\n        \"team_abbreviation\": \"SPY\",\n        \"url_slug\": \"spies\",\n        \"current_team_status\": \"active\",\n        \"valid_from\": \"2020-09-20T19:15:35.880Z\",\n        \"valid_until\": \"2020-09-27T01:24:03.154Z\",\n        \"gameday_from\": null,\n        \"season_from\": 6,\n        \"division\": \"Wild Low\",\n        \"division_id\": \"98c92da4-0ea7-43be-bd75-c6150e184326\",\n        \"league\": \"Wild\",\n        \"league_id\": \"aabc11a1-81af-4036-9f18-229c759ca8a9\",\n        \"tournament_name\": null,\n        \"modifications\": [\n            \"BLOOD_WINNER\",\n            \"SHAME_PIT\"\n        ],\n        \"team_main_color\": \"#67556b\",\n        \"team_secondary_color\": \"#9e82a4\",\n        \"team_slogan\": \"Bang BANG\",\n        \"team_emoji\": \"0x1F575\"\n    },\n    {\n        \"team_id\": \"a37f9158-7f82-46bc-908c-c9e2dda7c33b\",\n        \"location\": \"Breckenridge\",\n        \"nickname\": \"Jazz Hands\",\n        \"full_name\": \"Breckenridge Jazz Hands\",\n        \"team_abbreviation\": \"JAZZ\",\n        \"url_slug\": \"jazz-hands\",\n        \"current_team_status\": \"active\",\n        \"valid_from\": \"2020-09-20T19:15:35.880Z\",\n        \"valid_until\": \"2020-09-27T01:24:03.154Z\",\n        \"gameday_from\": null,\n        \"season_from\": 6,\n        \"division\": \"Wild High\",\n        \"division_id\": \"d4cc18de-a136-4271-84f1-32516be91a80\",\n        \"league\": \"Wild\",\n        \"league_id\": \"aabc11a1-81af-4036-9f18-229c759ca8a9\",\n        \"tournament_name\": null,\n        \"modifications\": [\n            \"BLOOD_PITY\",\n            \"SHAME_PIT\"\n        ],\n        \"team_main_color\": \"#6388ad\",\n        \"team_secondary_color\": \"#7ba9d7\",\n        \"team_slogan\": \"We’ve Got Winning to Do. Just for You.\",\n        \"team_emoji\": \"0x1F450\"\n    },\n    {\n        \"team_id\": \"adc5b394-8f76-416d-9ce9-813706877b84\",\n        \"location\": \"Kansas City\",\n        \"nickname\": \"Breath Mints\",\n        \"full_name\": \"Kansas City Breath Mints\",\n        \"team_abbreviation\": \"KCBM\",\n        \"url_slug\": \"breath-mints\",\n        \"current_team_status\": \"active\",\n        \"valid_from\": \"2020-09-20T19:15:35.880Z\",\n        \"valid_until\": \"2020-09-27T01:24:03.154Z\",\n        \"gameday_from\": null,\n        \"season_from\": 6,\n        \"division\": \"Mild High\",\n        \"division_id\": \"456089f0-f338-4620-a014-9540868789c9\",\n        \"league\": \"Mild\",\n        \"league_id\": \"4fe65afa-804f-4bb2-9b15-1281b2eab110\",\n        \"tournament_name\": null,\n        \"modifications\": [\n            \"BLOOD_DONOR\",\n            \"SHAME_PIT\"\n        ],\n        \"team_main_color\": \"#178f55\",\n        \"team_secondary_color\": \"#178f55\",\n        \"team_slogan\": \"Fresh Breath, Here We Come.\",\n        \"team_emoji\": \"0x1F36C\"\n    },\n    {\n        \"team_id\": \"b024e975-1c4a-4575-8936-a3754a08806a\",\n        \"location\": \"Dallas\",\n        \"nickname\": \"Steaks\",\n        \"full_name\": \"Dallas Steaks\",\n        \"team_abbreviation\": \"STK\",\n        \"url_slug\": \"steaks\",\n        \"current_team_status\": \"active\",\n        \"valid_from\": \"2020-09-20T19:15:35.880Z\",\n        \"valid_until\": \"2020-09-27T01:24:03.154Z\",\n        \"gameday_from\": null,\n        \"season_from\": 6,\n        \"division\": \"Mild High\",\n        \"division_id\": \"456089f0-f338-4620-a014-9540868789c9\",\n        \"league\": \"Mild\",\n        \"league_id\": \"4fe65afa-804f-4bb2-9b15-1281b2eab110\",\n        \"tournament_name\": null,\n        \"modifications\": [\n            \"BLOOD_DONOR\",\n            \"SHAME_PIT\"\n        ],\n        \"team_main_color\": \"#8c8d8f\",\n        \"team_secondary_color\": \"#b2b3b5\",\n        \"team_slogan\": \"Well Done.\",\n        \"team_emoji\": \"0x1F969\"\n    },\n    {\n        \"team_id\": \"b63be8c2-576a-4d6e-8daf-814f8bcea96f\",\n        \"location\": \"Miami\",\n        \"nickname\": \"Dale\",\n        \"full_name\": \"Miami Dale\",\n        \"team_abbreviation\": \"DALE\",\n        \"url_slug\": \"dale\",\n        \"current_team_status\": \"active\",\n        \"valid_from\": \"2020-09-20T19:15:35.880Z\",\n        \"valid_until\": \"2020-09-27T01:24:03.154Z\",\n        \"gameday_from\": null,\n        \"season_from\": 6,\n        \"division\": \"Wild Low\",\n        \"division_id\": \"98c92da4-0ea7-43be-bd75-c6150e184326\",\n        \"league\": \"Wild\",\n        \"league_id\": \"aabc11a1-81af-4036-9f18-229c759ca8a9\",\n        \"tournament_name\": null,\n        \"modifications\": [\n            \"BLOOD_WINNER\",\n            \"ELECTRIC\",\n            \"LIFE_OF_PARTY\",\n            \"SHAME_PIT\"\n        ],\n        \"team_main_color\": \"#9141ba\",\n        \"team_secondary_color\": \"#cd76fa\",\n        \"team_slogan\": \"¡Dale!\",\n        \"team_emoji\": \"0x1F6A4\"\n    },\n    {\n        \"team_id\": \"b72f3061-f573-40d7-832a-5ad475bd7909\",\n        \"location\": \"San Francisco\",\n        \"nickname\": \"Lovers\",\n        \"full_name\": \"San Francisco Lovers\",\n        \"team_abbreviation\": \"LVRS\",\n        \"url_slug\": \"lovers\",\n        \"current_team_status\": \"active\",\n        \"valid_from\": \"2020-09-20T19:15:35.880Z\",\n        \"valid_until\": \"2020-09-27T01:24:03.154Z\",\n        \"gameday_from\": null,\n        \"season_from\": 6,\n        \"division\": \"Wild High\",\n        \"division_id\": \"d4cc18de-a136-4271-84f1-32516be91a80\",\n        \"league\": \"Wild\",\n        \"league_id\": \"aabc11a1-81af-4036-9f18-229c759ca8a9\",\n        \"tournament_name\": null,\n        \"modifications\": [\n            \"BLOOD_PITY\",\n            \"SHAME_PIT\"\n        ],\n        \"team_main_color\": \"#780018\",\n        \"team_secondary_color\": \"#da0000\",\n        \"team_slogan\": \"Let's Go All The Way!\",\n        \"team_emoji\": \"0x1F48B\"\n    },\n    {\n        \"team_id\": \"bfd38797-8404-4b38-8b82-341da28b1f83\",\n        \"location\": \"Charleston\",\n        \"nickname\": \"Shoe Thieves\",\n        \"full_name\": \"Charleston Shoe Thieves\",\n        \"team_abbreviation\": \"CHST\",\n        \"url_slug\": \"shoe-thieves\",\n        \"current_team_status\": \"active\",\n        \"valid_from\": \"2020-09-06T19:00:36.117Z\",\n        \"valid_until\": \"2020-10-11T19:00:07.710Z\",\n        \"gameday_from\": null,\n        \"season_from\": 4,\n        \"division\": \"Mild Low\",\n        \"division_id\": \"fadc9684-45b3-47a6-b647-3be3f0735a84\",\n        \"league\": \"Mild\",\n        \"league_id\": \"4fe65afa-804f-4bb2-9b15-1281b2eab110\",\n        \"tournament_name\": null,\n        \"modifications\": [\n            \"BLOOD_THIEF\"\n        ],\n        \"team_main_color\": \"#ffce0a\",\n        \"team_secondary_color\": \"#ffce0a\",\n        \"team_slogan\": \"Your Kicks are My Kicks.\",\n        \"team_emoji\": \"0x1F45F\"\n    },\n    {\n        \"team_id\": \"ca3f1c8c-c025-4d8e-8eef-5be6accbeb16\",\n        \"location\": \"Chicago\",\n        \"nickname\": \"Firefighters\",\n        \"full_name\": \"Chicago Firefighters\",\n        \"team_abbreviation\": \"CHI\",\n        \"url_slug\": \"firefighters\",\n        \"current_team_status\": \"active\",\n        \"valid_from\": \"2020-09-20T19:15:35.880Z\",\n        \"valid_until\": \"2020-09-27T01:24:03.154Z\",\n        \"gameday_from\": null,\n        \"season_from\": 6,\n        \"division\": \"Wild High\",\n        \"division_id\": \"d4cc18de-a136-4271-84f1-32516be91a80\",\n        \"league\": \"Wild\",\n        \"league_id\": \"aabc11a1-81af-4036-9f18-229c759ca8a9\",\n        \"tournament_name\": null,\n        \"modifications\": [\n            \"BLOOD_PITY\",\n            \"SHAME_PIT\"\n        ],\n        \"team_main_color\": \"#8c2a3e\",\n        \"team_secondary_color\": \"#d13757\",\n        \"team_slogan\": \"We Are From Chicago\",\n        \"team_emoji\": \"0x1F525\"\n    },\n    {\n        \"team_id\": \"eb67ae5e-c4bf-46ca-bbbc-425cd34182ff\",\n        \"location\": \"Canada\",\n        \"nickname\": \"Moist Talkers\",\n        \"full_name\": \"Canada Moist Talkers\",\n        \"team_abbreviation\": \"CAN\",\n        \"url_slug\": \"moist-talkers\",\n        \"current_team_status\": \"active\",\n        \"valid_from\": \"2020-09-20T19:15:35.880Z\",\n        \"valid_until\": \"2020-09-27T01:24:03.154Z\",\n        \"gameday_from\": null,\n        \"season_from\": 6,\n        \"division\": \"Mild High\",\n        \"division_id\": \"456089f0-f338-4620-a014-9540868789c9\",\n        \"league\": \"Mild\",\n        \"league_id\": \"4fe65afa-804f-4bb2-9b15-1281b2eab110\",\n        \"tournament_name\": null,\n        \"modifications\": [\n            \"BLOOD_DONOR\",\n            \"SHAME_PIT\"\n        ],\n        \"team_main_color\": \"#f5feff\",\n        \"team_secondary_color\": \"#f5feff\",\n        \"team_slogan\": \"SPRAY IT, DON'T SAY IT\",\n        \"team_emoji\": \"0x1F5E3\"\n    },\n    {\n        \"team_id\": \"f02aeae2-5e6a-4098-9842-02d2273f25c7\",\n        \"location\": \"Hellmouth\",\n        \"nickname\": \"Sunbeams\",\n        \"full_name\": \"Hellmouth Sunbeams\",\n        \"team_abbreviation\": \"HELL\",\n        \"url_slug\": \"sunbeams\",\n        \"current_team_status\": \"active\",\n        \"valid_from\": \"2020-09-20T19:15:35.880Z\",\n        \"valid_until\": \"2020-09-27T01:24:03.154Z\",\n        \"gameday_from\": null,\n        \"season_from\": 6,\n        \"division\": \"Wild Low\",\n        \"division_id\": \"98c92da4-0ea7-43be-bd75-c6150e184326\",\n        \"league\": \"Wild\",\n        \"league_id\": \"aabc11a1-81af-4036-9f18-229c759ca8a9\",\n        \"tournament_name\": null,\n        \"modifications\": [\n            \"BLOOD_WINNER\",\n            \"SHAME_PIT\"\n        ],\n        \"team_main_color\": \"#fffbab\",\n        \"team_secondary_color\": \"#fffbab\",\n        \"team_slogan\": \"Stare into the Sun...\",\n        \"team_emoji\": \"0x1F31E\"\n    }\n]"
+								}
+							]
+						},
+						{
+							"name": "/teams/:teamIdOrSlug",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"pm.variables.set(\"teamIdOrSlug\", \"8d87c468-699a-47a8-b40d-cfb73a5660ad\");",
+											"pm.variables.set(\"season\", \"7\");"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"should respond with season 7 data for Baltimore Crabs\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.nickname).to.equal(\"Crabs\");",
+											"    pm.expect(jsonData.season_from).to.equal(6);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/v2/teams/{{teamIdOrSlug}}?season={{season}}",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"v2",
+										"teams",
+										"{{teamIdOrSlug}}"
+									],
+									"query": [
+										{
+											"key": "season",
+											"value": "{{season}}",
+											"description": "The (0-indexed) Blaseball season (or `current` for current season)"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "Team Stats",
+					"item": [
+						{
+							"name": "/stats/teams?type=season&season=14",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"should respond with 2 stat groups\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.length).to.equal(2);",
+											"});",
+											"",
+											"pm.test(\"should include 24 splits for hitting group\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    var hittingGroup = jsonData.find(function (statGroup) {",
+											"        return statGroup.group === 'hitting';",
+											"    });",
+											"    pm.expect(hittingGroup.totalSplits).to.equal(24);",
+											"});",
+											"",
+											"pm.test(\"should include 24 splits for pitching group\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    var pitchingGroup = jsonData.find(function (statGroup) {",
+											"        return statGroup.group === 'pitching';",
+											"    });",
+											"    pm.expect(pitchingGroup.totalSplits).to.equal(24);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/v2/stats/teams?type=season&gameType=R&group=pitching,hitting&season=14",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"v2",
+										"stats",
+										"teams"
+									],
+									"query": [
+										{
+											"key": "fields",
+											"value": "triples",
+											"description": "The stat fields to return (e.g. `strikeouts,home_runs` or `home_runs`)",
+											"disabled": true
+										},
+										{
+											"key": "sortStat",
+											"value": "",
+											"description": "The stat field to sort on",
+											"disabled": true
+										},
+										{
+											"key": "order",
+											"value": "",
+											"description": "The order of the sorted stat field (`asc` or `desc`)",
+											"disabled": true
+										},
+										{
+											"key": "sortStat",
+											"value": "",
+											"description": "The ID of a team to retrieve player stats for",
+											"disabled": true
+										},
+										{
+											"key": "limit",
+											"value": "",
+											"description": "The number of rows to return for each field (e.g. `5`",
+											"disabled": true
+										},
+										{
+											"key": "type",
+											"value": "season"
+										},
+										{
+											"key": "gameType",
+											"value": "R"
+										},
+										{
+											"key": "group",
+											"value": "pitching,hitting"
+										},
+										{
+											"key": "season",
+											"value": "14"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "Players",
+					"item": [
+						{
+							"name": "/players",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"pm.collectionVariables.set(\"season\", \"7\");"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"should respond with 20 players for season 7\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.length).to.equal(573);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/v2/players?season={{season}}",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"v2",
+										"players"
+									],
+									"query": [
+										{
+											"key": "season",
+											"value": "{{season}}"
+										},
+										{
+											"key": "playerPool",
+											"value": "deceased",
+											"disabled": true
+										},
+										{
+											"key": "sortField",
+											"value": "anticapitalism",
+											"disabled": true
+										},
+										{
+											"key": "order",
+											"value": "desc",
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "/players/:playerIdOrSlug",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"pm.collectionVariables.set(\"playerIdOrSlug\", \"dominic-marijuana\");"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"should respond with Dominic Marijuana's data\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.player_id).to.equal(\"7310c32f-8f32-40f2-b086-54555a2c0e86\");",
+											"    pm.expect(jsonData.debut_season).to.equal(2);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/v2/players/:playerIdOrSlug",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"v2",
+										"players",
+										":playerIdOrSlug"
+									],
+									"variable": [
+										{
+											"key": "playerIdOrSlug",
+											"value": "{{playerIdOrSlug}}",
+											"description": "A player's ID or URL slug"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "Player Stats",
+					"item": [
+						{
+							"name": "/stats?type=career",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"should respond with 2 stat groups\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.length).to.equal(2);",
+											"});",
+											"",
+											"pm.test(\"should include at least 286 splits for hitting group\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    var hittingGroup = jsonData.find(function (statGroup) {",
+											"        return statGroup.group === 'hitting';",
+											"    });",
+											"    pm.expect(hittingGroup.totalSplits).to.be.gte(286);",
+											"});",
+											"",
+											"pm.test(\"should include at least 139 splits for pitching group\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    var pitchingGroup = jsonData.find(function (statGroup) {",
+											"        return statGroup.group === 'pitching';",
+											"    });",
+											"    pm.expect(pitchingGroup.totalSplits).to.be.gte(139);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/v2/stats?type=career&group=hitting,pitching",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"v2",
+										"stats"
+									],
+									"query": [
+										{
+											"key": "type",
+											"value": "career",
+											"description": "The type of stat split (defaults to `season`)"
+										},
+										{
+											"key": "group",
+											"value": "hitting,pitching",
+											"description": "The stat groups to return (e.g. `hitting,pitching` or `hitting`)"
+										},
+										{
+											"key": "fields",
+											"value": "triples",
+											"description": "The stat fields to return (e.g. `strikeouts,home_runs` or `home_runs`)",
+											"disabled": true
+										},
+										{
+											"key": "season",
+											"value": "10",
+											"description": "The (0-indexed) Blaseball season (or `current` for current season)",
+											"disabled": true
+										},
+										{
+											"key": "gameType",
+											"value": "",
+											"description": "The type of game (e.g. `R` for regular season, `P` for postseason",
+											"disabled": true
+										},
+										{
+											"key": "sortStat",
+											"value": "",
+											"description": "The stat field to sort on",
+											"disabled": true
+										},
+										{
+											"key": "order",
+											"value": "",
+											"description": "The order of the sorted stat field (`asc` or `desc`)",
+											"disabled": true
+										},
+										{
+											"key": "playerId",
+											"value": "",
+											"description": "The ID of a player",
+											"disabled": true
+										},
+										{
+											"key": "teamId",
+											"value": "",
+											"description": "The ID of a team to retrieve player stats for",
+											"disabled": true
+										},
+										{
+											"key": "limit",
+											"value": "",
+											"description": "The number of rows to return for each field (e.g. `5`",
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "/stats?type=season&season=10",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"should respond with 2 stat groups\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.length).to.equal(2);",
+											"});",
+											"",
+											"pm.test(\"should include 227 splits for hitting group\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    var hittingGroup = jsonData.find(function (statGroup) {",
+											"        return statGroup.group === 'hitting';",
+											"    });",
+											"    pm.expect(hittingGroup.totalSplits).to.equal(227);",
+											"});",
+											"",
+											"pm.test(\"should include 100 splits for pitching group\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    var pitchingGroup = jsonData.find(function (statGroup) {",
+											"        return statGroup.group === 'pitching';",
+											"    });",
+											"    pm.expect(pitchingGroup.totalSplits).to.equal(100);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/v2/stats?type=season&group=hitting,pitching&season=10",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"v2",
+										"stats"
+									],
+									"query": [
+										{
+											"key": "type",
+											"value": "season",
+											"description": "The type of stat split (defaults to `season`)"
+										},
+										{
+											"key": "fields",
+											"value": "triples",
+											"description": "The stat fields to return (e.g. `strikeouts,home_runs` or `home_runs`)",
+											"disabled": true
+										},
+										{
+											"key": "gameType",
+											"value": "",
+											"description": "The type of game (e.g. `R` for regular season, `P` for postseason",
+											"disabled": true
+										},
+										{
+											"key": "sortStat",
+											"value": "",
+											"description": "The stat field to sort on",
+											"disabled": true
+										},
+										{
+											"key": "order",
+											"value": "",
+											"description": "The order of the sorted stat field (`asc` or `desc`)",
+											"disabled": true
+										},
+										{
+											"key": "playerId",
+											"value": "",
+											"description": "The ID of a player",
+											"disabled": true
+										},
+										{
+											"key": "teamId",
+											"value": "",
+											"description": "The ID of a team to retrieve player stats for",
+											"disabled": true
+										},
+										{
+											"key": "limit",
+											"value": "",
+											"description": "The number of rows to return for each field (e.g. `5`",
+											"disabled": true
+										},
+										{
+											"key": "group",
+											"value": "hitting,pitching"
+										},
+										{
+											"key": "season",
+											"value": "10"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "/stats?type=seasonCombined&season=10",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"should respond with 2 stat groups\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.length).to.equal(2);",
+											"});",
+											"",
+											"pm.test(\"should include 227 splits for hitting group\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    var hittingGroup = jsonData.find(function (statGroup) {",
+											"        return statGroup.group === 'hitting';",
+											"    });",
+											"    pm.expect(hittingGroup.totalSplits).to.equal(227);",
+											"});",
+											"",
+											"pm.test(\"should include 100 splits for pitching group\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    var pitchingGroup = jsonData.find(function (statGroup) {",
+											"        return statGroup.group === 'pitching';",
+											"    });",
+											"    pm.expect(pitchingGroup.totalSplits).to.equal(100);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/v2/stats?group=hitting,pitching&type=seasonCombined&season=10",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"v2",
+										"stats"
+									],
+									"query": [
+										{
+											"key": "fields",
+											"value": "triples",
+											"description": "The stat fields to return (e.g. `strikeouts,home_runs` or `home_runs`)",
+											"disabled": true
+										},
+										{
+											"key": "gameType",
+											"value": "",
+											"description": "The type of game (e.g. `R` for regular season, `P` for postseason",
+											"disabled": true
+										},
+										{
+											"key": "sortStat",
+											"value": "",
+											"description": "The stat field to sort on",
+											"disabled": true
+										},
+										{
+											"key": "order",
+											"value": "",
+											"description": "The order of the sorted stat field (`asc` or `desc`)",
+											"disabled": true
+										},
+										{
+											"key": "playerId",
+											"value": "a1628d97-16ca-4a75-b8df-569bae02bef9",
+											"description": "The ID of a player",
+											"disabled": true
+										},
+										{
+											"key": "teamId",
+											"value": "",
+											"description": "The ID of a team to retrieve player stats for",
+											"disabled": true
+										},
+										{
+											"key": "limit",
+											"value": "",
+											"description": "The number of rows to return for each field (e.g. `5`",
+											"disabled": true
+										},
+										{
+											"key": "group",
+											"value": "hitting,pitching"
+										},
+										{
+											"key": "type",
+											"value": "seasonCombined"
+										},
+										{
+											"key": "season",
+											"value": "10"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "/stats/leaders",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"should respond with 2 stat groups\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.length).to.equal(2);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/v2/stats/leaders?group=hitting,pitching&nocache=true",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"v2",
+										"stats",
+										"leaders"
+									],
+									"query": [
+										{
+											"key": "group",
+											"value": "hitting,pitching",
+											"description": "The stat groups to return (e.g. `hitting,pitching` or `hitting`)"
+										},
+										{
+											"key": "season",
+											"value": "",
+											"description": "The (0-indexed) Blaseball season (or `current` for current season)",
+											"disabled": true
+										},
+										{
+											"key": "type",
+											"value": "",
+											"description": "The type of leader results to return (e.g. `season` or `career`)",
+											"disabled": true
+										},
+										{
+											"key": "nocache",
+											"value": "true"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "/stats/leaders&type=career",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"should respond with 2 stat groups\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.length).to.equal(2);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/v2/stats/leaders?group=hitting,pitching&type=career",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"v2",
+										"stats",
+										"leaders"
+									],
+									"query": [
+										{
+											"key": "group",
+											"value": "hitting,pitching",
+											"description": "The stat groups to return (e.g. `hitting,pitching` or `hitting`)"
+										},
+										{
+											"key": "season",
+											"value": null,
+											"description": "The (0-indexed) Blaseball season (or `current` for current season)",
+											"disabled": true
+										},
+										{
+											"key": "type",
+											"value": "career",
+											"description": "The type of leader results to return (e.g. `season` or `career`)"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "Games",
+					"item": [
+						{
+							"name": "/games",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"pm.collectionVariables.set(\"season\", \"20\");"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"should respond with 1188 games for season 20\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.length).to.equal(1188);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/v2/games?season=current",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"v2",
+										"games"
+									],
+									"query": [
+										{
+											"key": "season",
+											"value": "current",
+											"description": "The (0-indexed) Blaseball season (or `current` for current season)."
+										},
+										{
+											"key": "day",
+											"value": "1",
+											"description": "The (0-indexed) Blaseball day (or `current` for current day).",
+											"disabled": true
+										},
+										{
+											"key": "teamIds",
+											"value": "7966eb04-efcc-499b-8f03-d13916330531",
+											"description": "A comma-separated list of team IDs.",
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "/games/:gameId",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"pm.collectionVariables.set(\"gameId\", \"dd652d5c-e265-406d-b396-c42c344ec1af\");"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"should respond with game data\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.game_id).to.equal(\"dd652d5c-e265-406d-b396-c42c344ec1af\");",
+											"    pm.expect(jsonData.season).to.equal(22);",
+											"    pm.expect(jsonData.day).to.equal(1);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/v2/games/:gameId",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"v2",
+										"games",
+										":gameId"
+									],
+									"variable": [
+										{
+											"key": "gameId",
+											"value": "dd652d5c-e265-406d-b396-c42c344ec1af"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "/games/:gameId/boxscore",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"pm.collectionVariables.set(\"gameId\", \"dd652d5c-e265-406d-b396-c42c344ec1af\");"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"should respond with game boxscore and player stats\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.game.game_id).to.equal(\"dd652d5c-e265-406d-b396-c42c344ec1af\");",
+											"    pm.expect(jsonData.teams.away.team.team_id).to.equal(\"7966eb04-efcc-499b-8f03-d13916330531\");",
+											"    pm.expect(jsonData.teams.away.playerStats.find(function (statGroup) {",
+											"        return statGroup.group === 'hitting';",
+											"    }).totalSplits).to.equal(5);",
+											"    pm.expect(jsonData.teams.away.playerStats.find(function (statGroup) {",
+											"        return statGroup.group === 'pitching';",
+											"    }).totalSplits).to.equal(1);",
+											"    pm.expect(jsonData.teams.home.team.team_id).to.equal(\"adc5b394-8f76-416d-9ce9-813706877b84\");",
+											"    pm.expect(jsonData.teams.home.playerStats.find(function (statGroup) {",
+											"        return statGroup.group === 'hitting';",
+											"    }).totalSplits).to.equal(6);",
+											"    pm.expect(jsonData.teams.home.playerStats.find(function (statGroup) {",
+											"        return statGroup.group === 'pitching';",
+											"    }).totalSplits).to.equal(1);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/v2/games/:gameId/boxscore",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"v2",
+										"games",
+										":gameId",
+										"boxscore"
+									],
+									"variable": [
+										{
+											"key": "gameId",
+											"value": "dd652d5c-e265-406d-b396-c42c344ec1af"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "/games/:gameId/events",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"pm.collectionVariables.set(\"gameId\", \"dd652d5c-e265-406d-b396-c42c344ec1af\");"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"should respond with game data and events\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.game.game_id).to.equal(\"dd652d5c-e265-406d-b396-c42c344ec1af\");",
+											"    pm.expect(jsonData.events[0].id).to.equal(1808773);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/v2/games/:gameId/events",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"v2",
+										"games",
+										":gameId",
+										"events"
+									],
+									"variable": [
+										{
+											"key": "gameId",
+											"value": "dd652d5c-e265-406d-b396-c42c344ec1af"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				}
+			]
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					"pm.test(\"Status code is 200\", function () {",
+					"    pm.response.to.have.status(200);",
+					"});",
+					"",
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"key": "baseUrl",
+			"value": "https://api.sibr.dev/datablase"
+		},
+		{
+			"key": "season",
+			"value": "7"
+		},
+		{
+			"key": "playerIdOrSlug",
+			"value": "dominic-marijuana"
+		},
+		{
+			"key": "gameId",
+			"value": ""
+		}
+	]
 }

--- a/lib/controllers/games.js
+++ b/lib/controllers/games.js
@@ -1,0 +1,68 @@
+import prisma from '../prisma.js';
+
+import { gameStats } from '../controllers/stats.js';
+import { getTimestampFromSeasonAndDay } from '../controllers/timeMap.js';
+
+export async function gameBoxScore({ gameId, teamId = null }) {
+  let result = {};
+
+  const gameResult = await prisma.game.findUnique({
+    where: {
+      game_id: gameId,
+    },
+  });
+
+  const gameDayTimestamp = await getTimestampFromSeasonAndDay({
+    season: gameResult.season,
+    day: gameResult.day,
+  });
+
+  // Extracted validity filter to use when grabbing properly timestamped home and away teams
+  const validTeamFilter = {
+    valid_from: {
+      lte: gameDayTimestamp,
+    },
+    OR: [
+      {
+        valid_until: {
+          gte: gameDayTimestamp,
+        },
+      },
+      {
+        valid_until: null,
+      },
+    ],
+  };
+
+  const teamsResult = await prisma.team.findMany({
+    where: {
+      OR: [
+        { team_id: gameResult.away_team },
+        { team_id: gameResult.home_team },
+      ],
+      AND: { ...validTeamFilter },
+    },
+  });
+
+  result.teams = {};
+
+  result.teams.away = {
+    team: teamsResult.find((team) => team.team_id === gameResult.away_team),
+    playerStats: await gameStats({
+      gameId,
+      teamId: gameResult.away_team,
+    }),
+  };
+
+  result.teams.home = {
+    team: teamsResult.find((team) => team.team_id === gameResult.home_team),
+    playerStats: await gameStats({
+      gameId,
+      teamId: gameResult.home_team,
+    }),
+  };
+
+  result.game = gameResult;
+
+  return result;
+}

--- a/lib/controllers/games.js
+++ b/lib/controllers/games.js
@@ -1,7 +1,46 @@
 import prisma from '../prisma.js';
 
 import { gameStats } from '../controllers/stats.js';
+import { getCurrentDay, getCurrentSeason } from '../controllers/timeMap.js';
 import { getTimestampFromSeasonAndDay } from '../controllers/timeMap.js';
+
+export async function games({ season, day, teamIds }) {
+  if (season === 'current') {
+    season = await getCurrentSeason();
+  }
+
+  if (day === 'current') {
+    day = await getCurrentDay();
+  }
+
+  const gamesResult = await prisma.game.findMany({
+    where: {
+      season,
+      day,
+      ...(teamIds != null
+        ? {
+            OR: [
+              { home_team: { in: teamIds } },
+              { away_team: { in: teamIds } },
+            ],
+          }
+        : {}),
+    },
+    orderBy: [{ season: 'desc' }, { day: 'asc' }],
+  });
+
+  return gamesResult;
+}
+
+export async function game({ gameId }) {
+  const gameResult = await prisma.game.findUnique({
+    where: {
+      game_id: gameId,
+    },
+  });
+
+  return gameResult;
+}
 
 export async function gameBoxScore({ gameId, teamId = null }) {
   let result = {};
@@ -65,4 +104,40 @@ export async function gameBoxScore({ gameId, teamId = null }) {
   result.game = gameResult;
 
   return result;
+}
+
+export async function gameEvents({ gameId }) {
+  const gameResult = await prisma.game.findUnique({
+    where: {
+      game_id: gameId,
+    },
+    include: {
+      game_events: {
+        orderBy: {
+          event_index: 'asc',
+        },
+        include: {
+          game_event_base_runners: {
+            orderBy: {
+              id: 'asc',
+            },
+          },
+          outcomes: {
+            orderBy: {
+              id: 'asc',
+            },
+          },
+        },
+      },
+    },
+  });
+
+  const { game_events, ...game } = gameResult;
+
+  const response = {
+    game: game,
+    events: game_events,
+  };
+
+  return response;
 }

--- a/lib/controllers/stats.js
+++ b/lib/controllers/stats.js
@@ -88,6 +88,98 @@ export async function statLeaders({ group, season, type = 'season' } = {}) {
   return response;
 }
 
+export async function gameStats({ gameId, teamId }) {
+  let response = [];
+
+  for (const statGroup of ['hitting', 'pitching']) {
+    let statGroupResult = {};
+    let view;
+
+    if (statGroup === 'hitting') {
+      view = prisma.playerBattingStatsGame;
+    } else if (statGroup === 'pitching') {
+      view = prisma.playerPitchingStatsGame;
+    }
+
+    const viewResults = await view.findMany({
+      where: {
+        game_id: gameId,
+        team_id: teamId,
+      },
+      include: statGroup === 'hitting' ? { runningStats: true } : undefined,
+    });
+
+    statGroupResult.group = statGroup;
+    statGroupResult.totalSplits = viewResults.length;
+    statGroupResult.splits = [];
+
+    for (const record of viewResults) {
+      const {
+        day,
+        game_id,
+        is_postseason,
+        player_id,
+        player_name,
+        season,
+        team_id,
+        team_valid_from,
+        team_valid_until,
+        weather_id,
+        ...stat
+      } = record;
+
+      // Merge stat fields from runningStats association object into stat object
+      if (Object.prototype.hasOwnProperty.call(stat, 'runningStats')) {
+        if (stat.runningStats !== null) {
+          // Discard unused non-base running stat fields
+          const {
+            day,
+            game_id,
+            player_id,
+            player_name,
+            season,
+            team,
+            team_id,
+            team_valid_until,
+            team_valid_from,
+            ...runningStats
+          } = stat.runningStats;
+
+          stat = { ...stat, ...runningStats };
+        } else {
+          // If a player does not have base running stats for a particular season, fill with 0s
+          BASE_RUNNING_FIELDS.forEach((baseRunningStat) => {
+            stat[baseRunningStat] = 0;
+          });
+        }
+
+        // Remove the association record since the fields were embedded into the `stat` property
+        delete stat.runningStats;
+      }
+
+      statGroupResult.splits.push({
+        gameId: game_id,
+        day,
+        season,
+        stat,
+        team: {
+          team_id,
+          team_valid_from,
+          team_valid_until,
+        },
+        player: {
+          id: player_id,
+          fullName: player_name,
+        },
+      });
+    }
+
+    response.push(statGroupResult);
+  }
+
+  return response;
+}
+
 export async function teamStats({
   fields,
   gameType = 'R',

--- a/lib/controllers/timeMap.js
+++ b/lib/controllers/timeMap.js
@@ -26,6 +26,19 @@ export async function getCurrentSeason() {
   return currentSeason.max.season;
 }
 
+export async function getCurrentDay() {
+  const currentDay = await prisma.timeMap.aggregate({
+    max: {
+      day: true,
+    },
+    where: {
+      season: await getCurrentSeason(),
+    },
+  });
+
+  return currentDay.max.season;
+}
+
 export async function getTimestampFromSeasonAndDay({ day, season }) {
   const timeMapRecord = await prisma.timeMap.findFirst({
     select: {

--- a/lib/routes/v2.js
+++ b/lib/routes/v2.js
@@ -1,5 +1,6 @@
 const Router = require('express-promise-router');
 
+const { gameBoxScore } = require('../controllers/games.js');
 const { config } = require('../controllers/config.js');
 const {
   playerStats,
@@ -162,15 +163,8 @@ router.get('/players/:playerIdOrSlug', async (req, res, next) => {
  * @returns {[object]} 200 - list of stat splits
  */
 router.get('/stats', async (req, res, next) => {
-  const {
-    gameType,
-    group,
-    order,
-    playerId,
-    sortStat,
-    teamId,
-    type,
-  } = req.query;
+  const { gameType, group, order, playerId, sortStat, teamId, type } =
+    req.query;
   const limit =
     req.query.limit !== undefined ? Number(req.query.limit) : undefined;
   const season =
@@ -251,15 +245,8 @@ router.get('/stats', async (req, res, next) => {
  * @returns {[object]} 200 - list of stat splits
  */
 router.get('/stats/teams', async (req, res, next) => {
-  const {
-    gameType,
-    group,
-    order,
-    playerId,
-    sortStat,
-    teamId,
-    type,
-  } = req.query;
+  const { gameType, group, order, playerId, sortStat, teamId, type } =
+    req.query;
   const limit =
     req.query.limit !== undefined ? Number(req.query.limit) : undefined;
   const season =
@@ -351,6 +338,28 @@ router.get('/stats/leaders', async (req, res, next) => {
   }
 
   const result = await statLeaders({ group, season, type });
+
+  res.json(result);
+});
+
+/**
+ * Gets the boxscore for a single game.
+ *
+ * @route GET /v2/games/:gameId/boxscore
+ * @group APIv2
+ * @param {string} gameId.path.required - The game ID.
+ * @returns {[object]} 200
+ */
+router.get('/games/:gameId/boxscore', async (req, res, next) => {
+  const { gameId } = req.params;
+
+  if (gameId === undefined) {
+    const err = new Error("Required path param 'gameId' missing.");
+    err.status = 400;
+    return next(err);
+  }
+
+  const result = await gameBoxScore({ gameId });
 
   res.json(result);
 });

--- a/lib/routes/v2.js
+++ b/lib/routes/v2.js
@@ -1,6 +1,11 @@
 const Router = require('express-promise-router');
 
-const { gameBoxScore } = require('../controllers/games.js');
+const {
+  game,
+  games,
+  gameBoxScore,
+  gameEvents,
+} = require('../controllers/games.js');
 const { config } = require('../controllers/config.js');
 const {
   playerStats,
@@ -343,6 +348,54 @@ router.get('/stats/leaders', async (req, res, next) => {
 });
 
 /**
+ * Gets game details.
+ *
+ * @route GET /v2/games
+ * @group APIv2
+ * @param {string} season.query - The (0-indexed) Blaseball season (or `current` for current season).
+ * @param {string} day.query - The (0-indexed) Blaseball day (or `current` for current day).
+ * @param {string} teamIds.query - A team ID to filter results on (includes home and away games).
+ * @returns {[object]} 200
+ */
+router.get('/games', async (req, res, next) => {
+  let { season, day, teamIds } = req.query;
+  teamIds = teamIds !== undefined ? teamIds.split(',') : undefined;
+  season =
+    season !== undefined
+      ? isNaN(season)
+        ? season
+        : Number(season)
+      : undefined;
+  day = day !== undefined ? (isNaN(day) ? day : Number(day)) : undefined;
+
+  const result = await games({ season, day, teamIds });
+
+  res.json(result);
+});
+
+/**
+ * Gets game details.
+ *
+ * @route GET /v2/games/:gameId
+ * @group APIv2
+ * @param {string} gameId.path.required - The game ID.
+ * @returns {[object]} 200
+ */
+router.get('/games/:gameId', async (req, res, next) => {
+  let { gameId } = req.params;
+
+  if (gameId === undefined) {
+    const err = new Error("Required path param 'gameId' missing.");
+    err.status = 400;
+    return next(err);
+  }
+
+  const result = await game({ gameId });
+
+  res.json(result);
+});
+
+/**
  * Gets the boxscore for a single game.
  *
  * @route GET /v2/games/:gameId/boxscore
@@ -360,6 +413,28 @@ router.get('/games/:gameId/boxscore', async (req, res, next) => {
   }
 
   const result = await gameBoxScore({ gameId });
+
+  res.json(result);
+});
+
+/**
+ * Gets game details and game events.
+ *
+ * @route GET /v2/games/:gameId/events
+ * @group APIv2
+ * @param {string} gameId.path.required - The game ID.
+ * @returns {[object]} 200
+ */
+router.get('/games/:gameId/events', async (req, res, next) => {
+  let { gameId } = req.params;
+
+  if (gameId === undefined) {
+    const err = new Error("Required path param 'gameId' missing.");
+    err.status = 400;
+    return next(err);
+  }
+
+  const result = await gameEvents({ gameId });
 
   res.json(result);
 });

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -139,6 +139,7 @@ model Game {
   statsheet_id           String?
   winning_pitcher_id     String?
   losing_pitcher_id      String?
+  outcomes               String[]
   game_events            GameEvent[]
 
   @@map("games")
@@ -319,8 +320,10 @@ model Team {
   stadium_name         String?
   stadium_nickname     String?
 
+  PlayerBattingStatsGame        PlayerBattingStatsGame[]
   PlayerBattingStatsSeason      PlayerBattingStatsSeason[]
   PlayerBattingStatsPostseason  PlayerBattingStatsPostseason[]
+  PlayerPitchingStatsGame       PlayerPitchingStatsGame[]
   PlayerPitchingStatsSeason     PlayerPitchingStatsSeason[]
   PlayerPitchingStatsPostseason PlayerPitchingStatsPostseason[]
 
@@ -349,6 +352,49 @@ model CurrentTeamRoster {
 }
 
 // Batting Stats
+
+// @View - Must be manually updated with every new Prisma introspection
+model PlayerBattingStatsGame {
+  game_id              String
+  player_id            String
+  player_name          String
+  team_id              String
+  team_valid_from      DateTime
+  team_valid_until     DateTime?
+  season               Int
+  day                  Int
+  batting_average      Float?
+  on_base_percentage   Float?
+  slugging             Float?
+  plate_appearances    Int
+  at_bats              Int
+  hits                 Int
+  walks                Int
+  singles              Int
+  doubles              Int
+  triples              Int
+  quadruples           Int
+  home_runs            Int
+  runs_batted_in       Float
+  strikeouts           Int
+  sacrifice_bunts      Int
+  sacrifice_flies      Int
+  at_bats_risp         Int
+  hits_risp            Int
+  batting_average_risp Float?
+  on_base_slugging     Float?
+  total_bases          Int
+  hit_by_pitches       Int
+  ground_outs          Int
+  flyouts              Int
+  gidp                 Int
+
+  runningStats PlayerRunningStatsGame?
+  team         Team                    @relation(fields: [team_id, team_valid_from], references: [team_id, valid_from])
+
+  @@id(fields: [game_id, player_id, team_id])
+  @@map("batting_stats_player_single_game")
+}
 
 // @View - Must be manually updated with every new Prisma introspection
 model PlayerBattingStatsSeason {
@@ -631,6 +677,46 @@ model TeamBattingStatsPostseason {
 // Pitching Stats
 
 // @View - Must be manually updated with every new Prisma introspection
+model PlayerPitchingStatsGame {
+  game_id           String
+  player_id         String
+  player_name       String
+  season            Int
+  day               Int
+  team_id           String
+  team_valid_from   DateTime
+  team_valid_until  DateTime?
+  wins              Int       @map("win")
+  losses            Int       @map("loss")
+  pitches_thrown    Int
+  top_of_inning     Boolean
+  batters_faced     Int
+  outs_recorded     Int
+  innings           Float
+  runs_allowed      Float
+  // shutouts            Int
+  // quality_starts      Int
+  strikeouts        Int
+  walks             Int
+  home_runs_allowed Int
+  hits_allowed      Int
+  hit_by_pitches    Float
+  // earned_run_average  Float
+  // walks_per_9         Float
+  // hits_per_9          Float
+  // strikeouts_per_9    Float
+  // home_runs_per_9     Float
+  // whip                Float
+  // strikeouts_per_walk Float
+  weather_id        Int
+
+  team Team @relation(fields: [team_id, team_valid_from], references: [team_id, valid_from])
+
+  @@id(fields: [game_id, player_id, team_id])
+  @@map("pitching_stats_all_appearances")
+}
+
+// @View - Must be manually updated with every new Prisma introspection
 model PlayerPitchingStatsSeason {
   player_id           String
   player_name         String
@@ -876,6 +962,27 @@ model TeamPitchingStatsPostseason {
 }
 
 // Base Running Stats
+
+// // @View - Must be manually updated with every new Prisma introspection
+model PlayerRunningStatsGame {
+  game_id          String
+  player_id        String
+  player_name      String
+  team             String?
+  team_id          String
+  team_valid_from  DateTime
+  team_valid_until DateTime?
+  season           Int
+  day              Int
+  stolen_bases     Int
+  caught_stealing  Int
+  runs             Float
+
+  battingStats PlayerBattingStatsGame @relation(fields: [game_id, player_id, team_id], references: [game_id, player_id, team_id])
+
+  @@id(fields: [game_id, player_id, team_id])
+  @@map("running_stats_player_single_game")
+}
 
 // @View - Must be manually updated with every new Prisma introspection
 model PlayerRunningStatsSeason {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,14 +9,14 @@ datasource db {
 
 model AppliedPatches {
   patch_id   Int     @id @default(autoincrement())
-  patch_hash String?
+  patch_hash String? @db.Uuid
 
   @@map("applied_patches")
 }
 
 model ChroniclerHashGameEvent {
   chronicler_hash_game_event_id Int        @id @default(autoincrement())
-  update_hash                   String?
+  update_hash                   String?    @db.Uuid
   game_event_id                 Int?
   game_events                   GameEvent? @relation(fields: [game_event_id], references: [id])
 
@@ -25,12 +25,14 @@ model ChroniclerHashGameEvent {
 }
 
 model ChroniclerMeta {
-  id               Int       @id
-  season           Float
-  day              Float
-  game_timestamp   DateTime?
-  team_timestamp   DateTime?
-  player_timestamp DateTime?
+  id                 Int       @id @db.SmallInt
+  season             Decimal   @db.Decimal
+  day                Decimal   @db.Decimal
+  game_timestamp     DateTime? @db.Timestamp(6)
+  team_timestamp     DateTime? @db.Timestamp(6)
+  player_timestamp   DateTime? @db.Timestamp(6)
+  division_timestamp DateTime? @db.Timestamp(6)
+  stadium_timestamp  DateTime? @db.Timestamp(6)
 
   @@map("chronicler_meta")
 }
@@ -38,15 +40,15 @@ model ChroniclerMeta {
 model GameEventBaseRunner {
   id                     Int        @id @default(autoincrement())
   game_event_id          Int?
-  runner_id              String?
-  responsible_pitcher_id String?
+  runner_id              String?    @db.VarChar(36)
+  responsible_pitcher_id String?    @db.VarChar(36)
   base_before_play       Int?
   base_after_play        Int?
   was_base_stolen        Boolean?
   was_caught_stealing    Boolean?
   was_picked_off         Boolean?
   runner_scored          Boolean?   @default(false)
-  runs_scored            Float?
+  runs_scored            Decimal?   @db.Decimal
   game_events            GameEvent? @relation(fields: [game_event_id], references: [id])
 
   @@map("game_event_base_runners")
@@ -54,42 +56,42 @@ model GameEventBaseRunner {
 
 model GameEvent {
   id                                 Int                       @id @default(autoincrement())
-  perceived_at                       DateTime?
-  game_id                            String?
+  perceived_at                       DateTime?                 @db.Timestamp(6)
+  game_id                            String?                   @db.VarChar(36)
   event_type                         String?
   event_index                        Int?
-  inning                             Int?
+  inning                             Int?                      @db.SmallInt
   top_of_inning                      Boolean?
-  outs_before_play                   Int?
-  batter_id                          String?
-  batter_team_id                     String?
-  pitcher_id                         String?
-  pitcher_team_id                    String?
-  home_score                         Float?
-  away_score                         Float?
+  outs_before_play                   Int?                      @db.SmallInt
+  batter_id                          String?                   @db.VarChar(36)
+  batter_team_id                     String?                   @db.VarChar(36)
+  pitcher_id                         String?                   @db.VarChar(36)
+  pitcher_team_id                    String?                   @db.VarChar(36)
+  home_score                         Decimal?                  @db.Decimal
+  away_score                         Decimal?                  @db.Decimal
   home_strike_count                  Int?                      @default(3)
   away_strike_count                  Int?                      @default(3)
   batter_count                       Int?
-  pitches                            String[]
-  total_strikes                      Int?
-  total_balls                        Int?
-  total_fouls                        Int?
+  pitches                            String[]                  @db.VarChar(1)
+  total_strikes                      Int?                      @db.SmallInt
+  total_balls                        Int?                      @db.SmallInt
+  total_fouls                        Int?                      @db.SmallInt
   is_leadoff                         Boolean?
   is_pinch_hit                       Boolean?
-  lineup_position                    Int?
+  lineup_position                    Int?                      @db.SmallInt
   is_last_event_for_plate_appearance Boolean?
-  bases_hit                          Int?
-  runs_batted_in                     Float?
+  bases_hit                          Int?                      @db.SmallInt
+  runs_batted_in                     Decimal?                  @db.Decimal
   is_sacrifice_hit                   Boolean?
   is_sacrifice_fly                   Boolean?
-  outs_on_play                       Int?
+  outs_on_play                       Int?                      @db.SmallInt
   is_double_play                     Boolean?
   is_triple_play                     Boolean?
   is_wild_pitch                      Boolean?
   batted_ball_type                   String?
   is_bunt                            Boolean?
-  errors_on_play                     Int?
-  batter_base_after_play             Int?
+  errors_on_play                     Int?                      @db.SmallInt
+  batter_base_after_play             Int?                      @db.SmallInt
   is_last_game_event                 Boolean?
   event_text                         String[]
   additional_context                 String?
@@ -104,6 +106,7 @@ model GameEvent {
   away_base_count                    Int?                      @default(4)
   home_base_count                    Int?                      @default(4)
   tournament                         Int?
+
   games                              Game?                     @relation(fields: [game_id], references: [game_id])
   chronicler_hash_game_event         ChroniclerHashGameEvent[]
   game_event_base_runners            GameEventBaseRunner[]
@@ -116,29 +119,29 @@ model GameEvent {
 }
 
 model Game {
-  game_id                String      @id
-  day                    Int
-  season                 Int
-  tournament             Int
+  game_id                String      @id @db.VarChar(36)
+  day                    Int?
+  season                 Int?
   last_game_event        Int?
-  home_odds              Float?
-  away_odds              Float?
+  home_odds              Decimal?    @db.Decimal
+  away_odds              Decimal?    @db.Decimal
   weather                Int?
   series_index           Int?
   series_length          Int?
   is_postseason          Boolean?
-  home_team              String?
-  away_team              String?
-  home_score             Float?
-  away_score             Float?
+  home_team              String?     @db.VarChar(36)
+  away_team              String?     @db.VarChar(36)
+  home_score             Decimal?    @db.Decimal
+  away_score             Decimal?    @db.Decimal
   number_of_innings      Int?
   ended_on_top_of_inning Boolean?
   ended_in_shame         Boolean?
-  terminology_id         String?
-  rules_id               String?
-  statsheet_id           String?
-  winning_pitcher_id     String?
-  losing_pitcher_id      String?
+  terminology_id         String?     @db.VarChar(36)
+  rules_id               String?     @db.VarChar(36)
+  statsheet_id           String?     @db.VarChar(36)
+  winning_pitcher_id     String?     @db.VarChar
+  losing_pitcher_id      String?     @db.VarChar
+  tournament             Int?
   outcomes               String[]
   game_events            GameEvent[]
 
@@ -148,7 +151,7 @@ model Game {
 model ImportedLog {
   id          Int       @id @default(autoincrement())
   key         String?
-  imported_at DateTime?
+  imported_at DateTime? @db.Timestamp(6)
 
   @@map("imported_logs")
 }
@@ -156,7 +159,7 @@ model ImportedLog {
 model Outcome {
   id            Int        @id @default(autoincrement())
   game_event_id Int?
-  entity_id     String?
+  entity_id     String?    @db.VarChar(36)
   event_type    String?
   original_text String?
   game_events   GameEvent? @relation(fields: [game_event_id], references: [id])
@@ -166,10 +169,11 @@ model Outcome {
 
 model PlayerModification {
   player_modifications_id Int       @id @default(autoincrement())
-  player_id               String?
-  modification            String?
-  valid_from              DateTime?
-  valid_until             DateTime?
+  player_id               String?   @db.VarChar
+  modification            String?   @db.VarChar
+  valid_from              DateTime? @db.Timestamp(6)
+  valid_until             DateTime? @db.Timestamp(6)
+  tournament              Int?      @default(-1)
 
   @@index([player_id, valid_from, valid_until], name: "player_modifications_indx_player_id_timespan")
   @@map("player_modifications")
@@ -177,22 +181,23 @@ model PlayerModification {
 
 model TeamModification {
   team_modifications_id Int       @id @default(autoincrement())
-  team_id               String?
-  modification          String?
-  valid_from            DateTime?
-  valid_until           DateTime?
+  team_id               String?   @db.VarChar
+  modification          String?   @db.VarChar
+  valid_from            DateTime? @db.Timestamp(6)
+  valid_until           DateTime? @db.Timestamp(6)
 
   @@map("team_modifications")
 }
 
 model TeamRoster {
   team_roster_id   Int       @id @default(autoincrement())
-  team_id          String?
+  team_id          String?   @db.VarChar
   position_id      Int?
-  valid_from       DateTime?
-  valid_until      DateTime?
-  player_id        String?
-  position_type_id Float?
+  valid_from       DateTime? @db.Timestamp(6)
+  valid_until      DateTime? @db.Timestamp(6)
+  player_id        String?   @db.VarChar
+  position_type_id Decimal?  @db.Decimal
+  tournament       Int?      @default(-1)
 
   @@index([valid_until, team_id, position_id, position_type_id], name: "team_roster_idx")
   @@index([player_id, valid_from, valid_until], name: "team_roster_indx_player_id_timespan")
@@ -202,7 +207,7 @@ model TeamRoster {
 model TimeMap {
   season      Int
   day         Int
-  first_time  DateTime?
+  first_time  DateTime? @db.Timestamp(6)
   time_map_id Int       @id @default(autoincrement())
   phase_id    Int?
 
@@ -212,49 +217,53 @@ model TimeMap {
 
 // @View - Must be manually updated with every new Prisma introspection
 model Player {
-  player_id        String
-  player_name      String?
-  valid_from       DateTime
-  valid_until      DateTime?
-  deceased         Boolean?
-  anticapitalism   Float?
-  base_thirst      Float?
-  buoyancy         Float?
-  chasiness        Float?
-  coldness         Float?
-  continuation     Float?
-  divinity         Float?
-  ground_friction  Float?
-  indulgence       Float?
-  laserlikeness    Float?
-  martyrdom        Float?
-  moxie            Float?
-  musclitude       Float?
-  omniscience      Float?
-  overpowerment    Float?
-  patheticism      Float?
-  ruthlessness     Float?
-  shakespearianism Float?
-  suppression      Float?
-  tenaciousness    Float?
-  thwackability    Float?
-  tragicness       Float?
-  unthwackability  Float?
-  watchfulness     Float?
-  pressurization   Float?
-  cinnamon         Float?
-  total_fingers    Int?
-  soul             Int?
-  fate             Int?
-  peanut_allergy   Boolean?
-  armor            String?
-  bat              String?
-  ritual           String?
-  coffee           String?
-  blood            String?
-  url_slug         String?
+  player_id          String    @db.VarChar(36)
+  valid_from         DateTime  @db.Timestamp(6)
+  valid_until        DateTime? @db.Timestamp(6)
+  player_name        String?   @db.VarChar
+  deceased           Boolean?
+  anticapitalism     Decimal?  @db.Decimal
+  base_thirst        Decimal?  @db.Decimal
+  buoyancy           Decimal?  @db.Decimal
+  chasiness          Decimal?  @db.Decimal
+  coldness           Decimal?  @db.Decimal
+  continuation       Decimal?  @db.Decimal
+  divinity           Decimal?  @db.Decimal
+  ground_friction    Decimal?  @db.Decimal
+  indulgence         Decimal?  @db.Decimal
+  laserlikeness      Decimal?  @db.Decimal
+  martyrdom          Decimal?  @db.Decimal
+  moxie              Decimal?  @db.Decimal
+  musclitude         Decimal?  @db.Decimal
+  omniscience        Decimal?  @db.Decimal
+  overpowerment      Decimal?  @db.Decimal
+  patheticism        Decimal?  @db.Decimal
+  ruthlessness       Decimal?  @db.Decimal
+  shakespearianism   Decimal?  @db.Decimal
+  suppression        Decimal?  @db.Decimal
+  tenaciousness      Decimal?  @db.Decimal
+  thwackability      Decimal?  @db.Decimal
+  tragicness         Decimal?  @db.Decimal
+  unthwackability    Decimal?  @db.Decimal
+  watchfulness       Decimal?  @db.Decimal
+  pressurization     Decimal?  @db.Decimal
+  cinnamon           Decimal?  @db.Decimal
+  total_fingers      Int?      @db.SmallInt
+  soul               Int?      @db.SmallInt
+  fate               Int?      @db.SmallInt
+  peanut_allergy     Boolean?
+  armor              String?
+  bat                String?
+  ritual             String?
+  url_slug           String?   @db.VarChar
+  evolution          Int?      @default(0)
+  batting_rating     Decimal?  @default(-1) @db.Decimal
+  pitching_rating    Decimal?  @default(-1) @db.Decimal
+  baserunning_rating Decimal?  @default(-1) @db.Decimal
+  defense_rating     Decimal?  @default(-1) @db.Decimal
 
-  evolution               Float?
+  blood              String?
+  coffee             String?
   current_state           String?
   current_location        String?
   debut_gameday           Int?
@@ -273,13 +282,9 @@ model Player {
   team_abbreviation       String?
   team_id                 String?
   modifications           String[]
-  baserunning_rating      Float?
   baserunning_stars       Float?
-  batting_rating          Float?
   batting_stars           Float?
-  defense_rating          Float?
   defense_stars           Float?
-  pitching_rating         Float?
   pitching_stars          Float?
   items                   String[]
   durabilities            Float[]
@@ -295,30 +300,32 @@ model Player {
 
 // @View - Must be manually updated with every new Prisma introspection
 model Team {
-  team_id              String
+  team_id              String    @db.VarChar(36)
   location             String
   nickname             String
   full_name            String
-  team_abbreviation    String?
-  url_slug             String
-  team_current_status  String?
-  valid_from           DateTime
-  valid_until          DateTime?
-  gameday_from         Int?
-  season_from          Int?
-  division             String?
-  division_id          String?
-  league               String?
-  league_id            String?
-  tournament_name      String?
-  modifications        String[]
-  team_main_color      String?
-  team_secondary_color String?
-  team_slogan          String?
-  team_emoji           String?
-  stadium_id           String?
-  stadium_name         String?
-  stadium_nickname     String?
+  valid_from           DateTime  @db.Timestamp(6)
+  valid_until          DateTime? @db.Timestamp(6)
+  url_slug             String    @db.VarChar
+  stadium_id           String?   @default("") @db.VarChar(36)
+  team_abbreviation    String?   @default("") @db.VarChar(10)
+  team_main_color      String?   @default("") @db.VarChar(10)
+  team_secondary_color String?   @default("") @db.VarChar(10)
+  team_emoji           String?   @default("") @db.VarChar
+  team_slogan          String?   @default("") @db.VarChar
+  // deceased             Boolean   @default(false)
+
+  team_current_status String?
+  gameday_from        Int?
+  season_from         Int?
+  division            String?
+  division_id         String?
+  league              String?
+  league_id           String?
+  tournament_name     String?
+  modifications       String[]
+  stadium_name        String?
+  stadium_nickname    String?
 
   PlayerBattingStatsGame        PlayerBattingStatsGame[]
   PlayerBattingStatsSeason      PlayerBattingStatsSeason[]
@@ -358,9 +365,9 @@ model PlayerBattingStatsGame {
   game_id              String
   player_id            String
   player_name          String
-  team_id              String
-  team_valid_from      DateTime
-  team_valid_until     DateTime?
+  team_id              String    @db.VarChar(36)
+  team_valid_from      DateTime  @db.Timestamp(6)
+  team_valid_until     DateTime? @db.Timestamp(6)
   season               Int
   day                  Int
   batting_average      Float?
@@ -400,9 +407,9 @@ model PlayerBattingStatsGame {
 model PlayerBattingStatsSeason {
   player_id            String
   player_name          String
-  team_id              String
-  team_valid_from      DateTime
-  team_valid_until     DateTime?
+  team_id              String    @db.VarChar(36)
+  team_valid_from      DateTime  @db.Timestamp(6)
+  team_valid_until     DateTime? @db.Timestamp(6)
   season               Int
   first_appearance     Int
   batting_average      Float?
@@ -482,9 +489,9 @@ model PlayerBattingStatsSeasonCombined {
 model PlayerBattingStatsPostseason {
   player_id            String
   player_name          String
-  team_id              String
-  team_valid_from      DateTime
-  team_valid_until     DateTime?
+  team_id              String    @db.VarChar(36)
+  team_valid_from      DateTime  @db.Timestamp(6)
+  team_valid_until     DateTime? @db.Timestamp(6)
   season               Int
   batting_average      Float?
   on_base_percentage   Float?
@@ -596,9 +603,9 @@ model PlayerBattingStatsPostseasonLifetime {
 
 // @View - Must be manually updated with every new Prisma introspection
 model TeamBattingStatsSeason {
-  team_id              String
-  team_valid_from      DateTime
-  team_valid_until     DateTime?
+  team_id              String    @db.VarChar(36)
+  team_valid_from      DateTime  @db.Timestamp(6)
+  team_valid_until     DateTime? @db.Timestamp(6)
   season               Int
   batting_average      Float?
   on_base_percentage   Float?
@@ -636,9 +643,9 @@ model TeamBattingStatsSeason {
 
 // @View - Must be manually updated with every new Prisma introspection
 model TeamBattingStatsPostseason {
-  team_id              String
-  team_valid_from      DateTime
-  team_valid_until     DateTime?
+  team_id              String    @db.VarChar(36)
+  team_valid_from      DateTime  @db.Timestamp(6)
+  team_valid_until     DateTime? @db.Timestamp(6)
   season               Int
   batting_average      Float?
   on_base_percentage   Float?
@@ -683,9 +690,9 @@ model PlayerPitchingStatsGame {
   player_name       String
   season            Int
   day               Int
-  team_id           String
-  team_valid_from   DateTime
-  team_valid_until  DateTime?
+  team_id           String    @db.VarChar(36)
+  team_valid_from   DateTime  @db.Timestamp(6)
+  team_valid_until  DateTime? @db.Timestamp(6)
   wins              Int       @map("win")
   losses            Int       @map("loss")
   pitches_thrown    Int
@@ -721,9 +728,9 @@ model PlayerPitchingStatsSeason {
   player_id           String
   player_name         String
   season              Int
-  team_id             String
-  team_valid_from     DateTime
-  team_valid_until    DateTime?
+  team_id             String    @db.VarChar(36)
+  team_valid_from     DateTime  @db.Timestamp(6)
+  team_valid_until    DateTime? @db.Timestamp(6)
   games               Int
   wins                Int
   losses              Int
@@ -792,9 +799,9 @@ model PlayerPitchingStatsPostseason {
   player_id           String
   player_name         String
   season              Int
-  team_id             String
-  team_valid_from     DateTime
-  team_valid_until    DateTime?
+  team_id             String    @db.VarChar(36)
+  team_valid_from     DateTime  @db.Timestamp(6)
+  team_valid_until    DateTime? @db.Timestamp(6)
   games               Int
   wins                Int
   losses              Int
@@ -892,9 +899,9 @@ model PlayerPitchingStatsPostseasonLifetime {
 // @View - Must be manually updated with every new Prisma introspection
 model TeamPitchingStatsSeason {
   season              Int
-  team_id             String
-  team_valid_from     DateTime
-  team_valid_until    DateTime?
+  team_id             String    @db.VarChar(36)
+  team_valid_from     DateTime  @db.Timestamp(6)
+  team_valid_until    DateTime? @db.Timestamp(6)
   games               Int
   wins                Int
   losses              Int
@@ -928,9 +935,9 @@ model TeamPitchingStatsSeason {
 // @View - Must be manually updated with every new Prisma introspection
 model TeamPitchingStatsPostseason {
   season              Int
-  team_id             String
-  team_valid_from     DateTime
-  team_valid_until    DateTime?
+  team_id             String    @db.VarChar(36)
+  team_valid_from     DateTime  @db.Timestamp(6)
+  team_valid_until    DateTime? @db.Timestamp(6)
   games               Int
   wins                Int
   losses              Int
@@ -969,9 +976,9 @@ model PlayerRunningStatsGame {
   player_id        String
   player_name      String
   team             String?
-  team_id          String
-  team_valid_from  DateTime
-  team_valid_until DateTime?
+  team_id          String    @db.VarChar(36)
+  team_valid_from  DateTime  @db.Timestamp(6)
+  team_valid_until DateTime? @db.Timestamp(6)
   season           Int
   day              Int
   stolen_bases     Int
@@ -989,9 +996,9 @@ model PlayerRunningStatsSeason {
   player_id        String
   player_name      String
   team             String?
-  team_id          String
-  team_valid_from  DateTime?
-  team_valid_until DateTime?
+  team_id          String    @db.VarChar(36)
+  team_valid_from  DateTime  @db.Timestamp(6)
+  team_valid_until DateTime? @db.Timestamp(6)
   season           Int
   stolen_bases     Int
   caught_stealing  Int
@@ -1023,9 +1030,9 @@ model PlayerRunningStatsPostseason {
   player_id        String
   player_name      String
   team             String?
-  team_id          String
-  team_valid_from  DateTime?
-  team_valid_until DateTime?
+  team_id          String    @db.VarChar(36)
+  team_valid_from  DateTime  @db.Timestamp(6)
+  team_valid_until DateTime? @db.Timestamp(6)
   season           Int
   stolen_bases     Int
   caught_stealing  Int
@@ -1068,7 +1075,7 @@ model PlayerRunningStatsPostseasonLifetime {
 // @View - Must be manually updated with every new Prisma introspection
 model TeamRunningStatsSeason {
   team            String?
-  team_id         String
+  team_id         String  @db.VarChar(36)
   season          Int
   stolen_bases    Int
   caught_stealing Int
@@ -1083,7 +1090,7 @@ model TeamRunningStatsSeason {
 // @View - Must be manually updated with every new Prisma introspection
 model TeamRunningStatsPostseason {
   team            String?
-  team_id         String
+  team_id         String  @db.VarChar(36)
   season          Int
   stolen_bases    Int
   caught_stealing Int

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -301,7 +301,7 @@ model Team {
   full_name            String
   team_abbreviation    String?
   url_slug             String
-  team_current_status  String
+  team_current_status  String?
   valid_from           DateTime
   valid_until          DateTime?
   gameday_from         Int?


### PR DESCRIPTION
Adds the following endpoints for retrieving game-specific data:

`/v2/games` returns multi-game data, not including game events and game event outcomes. Accepts the following params: 'season', 'day', 'teamIds'.

`/v2/games/:gameId` returns game data for a gameId, not including game events and game event outcomes.

`/v2/games/:gameId/events` returns game data as well as game events and game event outcomes for a gameId.

`/v2/games/:gameId/boxscore` returns team data, player stats, and game data for a gameId. 